### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+Only the most recent release line receives security updates.
+
+| Version | Supported          |
+|---------|--------------------|
+| 14.x    | :white_check_mark: |
+| < 14.0  | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security issue in Moon Downloader (for example: a code path
+that could leak local files, execute untrusted downloads, or expose proxy
+credentials), please **do not** open a public issue.
+
+Report it privately through GitHub Security Advisories:
+
+<https://github.com/LeyckerS/moondownloader/security/advisories/new>
+
+Please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- The affected version(s)
+
+You should receive an acknowledgement within 7 days. Once confirmed and
+patched, the reporter will be credited in the release notes unless they
+prefer to remain anonymous.


### PR DESCRIPTION
GitHub's community-health checks flag a missing `SECURITY.md`. Added a short one that points would-be reporters at the private **Security advisories** flow instead of the public issue tracker.

The reporting URL is the repo's advisories page — no email address exposed.