### PR TITLE
ci: add lightweight syntax-check workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.py"
+      - ".github/workflows/lint.yml"
+  pull_request:
+    paths:
+      - "**.py"
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Byte-compile all Python files
+        run: |
+          python -m compileall -q gen_1.py gen_cli.py
+
+      - name: Check for syntax errors with py_compile
+        run: |
+          python -c "import py_compile; py_compile.compile('gen_1.py', doraise=True)"
+          python -c "import py_compile; py_compile.compile('gen_cli.py', doraise=True)"


### PR DESCRIPTION
Adds a tiny GitHub Actions workflow that runs on every push / PR touching `.py` files. It just byte-compiles `gen_1.py` and `gen_cli.py` on Python 3.10 to catch obvious `SyntaxError` regressions before merge.

Deliberately minimal:
- No linter (no `ruff`/`flake8`/`mypy`) so it can't fail on style opinions.
- No dependency install — `py_compile` is stdlib.
- Runs on a single Python version.

Respects the CONTRIBUTING.md rule about not adding tooling for the sake of tooling; this just catches typos.