### PR TITLE
chore: enable Dependabot for pip + GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Python dependencies in requirements.txt
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Rome
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+
+  # GitHub Actions workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "chore(actions)"


### PR DESCRIPTION
Enables Dependabot to open weekly PRs for `pip` dependency updates (aiohttp, playwright, pillow) and monthly PRs for any GitHub Actions used in workflows.

Configured with:
- Weekly pip runs on Monday 09:00 Europe/Rome (author timezone)
- Max 5 open pip PRs at any time
- Conventional-commit-style prefixes (`chore(deps):`)
- `dependencies` label on everything so they're easy to filter