### PR TITLE
chore(gitignore): add macOS and Windows OS artifact entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,19 @@ eni_launcher.bat
 # Node
 node_modules/
 package-lock.json
+
+
+# macOS
+.DS_Store
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+
+# Windows extras
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+Desktop.ini
+$RECYCLE.BIN/
+*.lnk


### PR DESCRIPTION
`.gitignore` already covers logs, Python, IDE folders and downloaded media, but not the small metadata files that macOS and Windows sprinkle into working directories (`.DS_Store`, `Thumbs.db`, etc.).

Added standard entries so those don't get accidentally committed by contributors on those platforms.