### PR TITLE
chore(avvia.bat): show English error alongside Italian

### DIFF
--- a/avvia.bat
+++ b/avvia.bat
@@ -7,6 +7,9 @@ py --version >nul 2>&1 && set "PY=py"
 if not defined PY (python --version >nul 2>&1 && set "PY=python")
 if not defined PY (python3 --version >nul 2>&1 && set "PY=python3")
 if not defined PY (
+    echo [ERROR] Python not found. Please install Python 3.10+ from https://www.python.org
+    echo         Make sure to check "Add Python to PATH" during installation.
+    echo.
     echo [ERRORE] Python non trovato. Installa Python 3.10+ da https://www.python.org
     echo          Assicurati di spuntare "Add Python to PATH" durante l'installazione.
     pause


### PR DESCRIPTION
The `avvia.bat` launcher currently prints Python-not-found errors only in Italian, which can confuse non-Italian users who cloned the repo.

Added an English translation right above the Italian message. Both are shown so existing users don't lose their native-language instructions.