### PR TITLE
chore(deps): add upper version bounds to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
 aiohttp>=3.14.1
 playwright>=1.61.0
 pillow>=10.0  # optional — used for custom logo scaling
+
+# Core dependencies
+aiohttp>=3.9,<4.0
+playwright>=1.40,<2.0
+
+# Optional — used for custom logo scaling in the GUI
+pillow>=10.0,<12.0


### PR DESCRIPTION
The current `requirements.txt` uses open-ended lower-bound constraints (`>=`), which means a future major release of aiohttp, playwright or pillow could break users doing a fresh install.

Added conservative upper bounds within the current major version. Should have zero effect on existing users but protects against surprise breakage on the next Playwright 2.x or aiohttp 4.x.