### PR TITLE
chore: add PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description
+
+<!-- Briefly describe what this PR changes and why. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would change existing behavior)
+- [ ] Documentation update
+- [ ] Refactor / code cleanup
+- [ ] Other:
+
+## Checklist
+
+- [ ] I have tested my changes locally
+- [ ] If this affects shared logic (extraction, download engine), I also
+      applied the equivalent change to `gen_cli.py`
+- [ ] I have kept the single-file architecture (no package split)
+- [ ] I have not added new dependencies without justification in the PR
+      description
+
+## Screenshots / logs (if applicable)
+
+<!-- Attach screenshots or `moontech_*.log` snippets if this is a UI or
+     download-engine change. -->


### PR DESCRIPTION
PR template mirroring the rules already in `CONTRIBUTING.md`:

- Test locally
- Mirror `gen_1.py` changes to `gen_cli.py` when shared
- Preserve single-file architecture
- Justify new deps

Nothing new policy-wise — just a checkbox reminder for people opening PRs.