### PR TITLE
chore: add .editorconfig for consistent whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig helps maintain consistent coding styles across
+# different editors and IDEs. See https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.py]
+max_line_length = 120
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.bat]
+end_of_line = crlf
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Small quality-of-life addition: an `.editorconfig` so that anyone opening the repo in VS Code, PyCharm, Vim, etc. automatically gets 4-space indent for Python, 2-space for YAML, LF endings everywhere except `.bat` (which needs CRLF).

This is purely tooling metadata — no behavior change.