### PR TITLE
docs(templates): disable blank issues, add contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Read the docs first
+    url: https://github.com/LeyckerS/moondownloader#readme
+    about: |
+      Most common questions (install, providers, settings) are answered
+      in the README. Please skim it before opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/LeyckerS/moondownloader/security/advisories/new
+    about: |
+      Please report security issues privately through GitHub Security
+      Advisories — not the public issue tracker.


### PR DESCRIPTION
Small hygiene addition once the bug/feature templates exist:

- `blank_issues_enabled: false` forces users through one of the structured templates.
- Two `contact_links` pointing users at the README (for common questions) and the Security Advisories page (for CVEs).