### PR TITLE
docs: add AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,15 @@
+# Authors
+
+Moon Downloader is created and maintained by:
+
+- **LeyckerS** — [github.com/LeyckerS](https://github.com/LeyckerS)
+
+## Contributors
+
+Thank you to everyone who has helped improve this project. The full,
+auto-updated list of contributors is visible on GitHub:
+
+<https://github.com/LeyckerS/moondownloader/graphs/contributors>
+
+If you've contributed and would like to be listed here explicitly (with a
+short bio or link), open a PR editing this file.


### PR DESCRIPTION
Standalone authors file pointing at the auto-generated contributors graph. Some tooling (packaging, license aggregators) looks for `AUTHORS` / `AUTHORS.md` specifically.