### PR TITLE
docs: fix line count in README architecture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Place in the same folder as `gen_1.py`:
 
 ## 🏗️ Architecture
 
-Single-file application (~1500 lines), structured in layers:
+Single-file application (~1350 lines), structured in layers:
 
 ```
 gen_1.py


### PR DESCRIPTION
The Architecture section of the README states `gen_1.py` is ~1500 lines, but the actual file is 1350 lines (which matches the number in `CONTRIBUTING.md`). Updated the README so both docs agree.

Verified with `wc -l gen_1.py` on `main` (commit HEAD).