### PR TITLE
Add CLI documentation and link it in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Full write-up: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
 | Document | What's in it |
 |:--|:--|
 | [Quick start](docs/QUICKSTART.md) | install, first run, what each setting does |
+| [CLI Reference](docs/CLI.md) | command-line arguments for headless/server usage |
 | [Configuration](docs/CONFIGURATION.md) | every setting, every environment variable, the Chrome profile |
 | [Providers](docs/PROVIDERS.md) | how each host is extracted, and how to add another |
 | [Architecture](docs/ARCHITECTURE.md) | how V2 is built, feature by feature |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,57 @@
+# CLI Reference
+
+MoonDownloader CLI — headless downloader for server deployment.
+
+This document covers all command-line arguments for `moon_cli.py`, intended for users running MoonDownloader on a server or in any environment without a graphical interface.
+
+## Basic Usage
+
+```bash
+python moon_cli.py --urls urls.txt --output ./downloads
+```
+
+## Arguments
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `--urls` | Yes | — | Path to a text file containing one URL per line |
+| `--output` | Yes | — | Output folder where downloaded files will be saved |
+| `--browsers` | No | `8` | Number of parallel extraction workers |
+| `--streams` | No | `24` | Number of concurrent download streams |
+| `--retries` | No | `3` | Maximum number of retries per failed link |
+| `--proxies` | No | `proxies.txt` | Path to a proxy list file |
+
+## Examples
+
+### Minimal run
+
+```bash
+python moon_cli.py --urls urls.txt --output ./downloads
+```
+
+### Custom concurrency
+
+Increase parallel workers and download streams for faster throughput on a powerful server:
+
+```bash
+python moon_cli.py --urls urls.txt --output ./downloads --browsers 16 --streams 48
+```
+
+### Custom retry and proxy settings
+
+```bash
+python moon_cli.py --urls urls.txt --output ./downloads --retries 5 --proxies my_proxies.txt
+```
+
+## Notes
+
+- `--urls` file format: one URL per line, no additional formatting required.
+- `--browsers` controls how many headless browser instances run in parallel to extract download links. Higher values speed up extraction but use more memory and CPU.
+- `--streams` controls how many files can be downloaded concurrently. Higher values increase throughput but may trigger rate limits on some providers.
+- If `--proxies` is not specified, MoonDownloader looks for `proxies.txt` in the current working directory. If the file does not exist, requests are made without a proxy.
+
+## See Also
+
+- [QUICKSTART.md](./QUICKSTART.md)
+- [CONFIGURATION.md](./CONFIGURATION.md)
+- [PROVIDERS.md](./PROVIDERS.md)


### PR DESCRIPTION
## Description

Added a new documentation file (docs/CLI.md) explaining how to use the command-line interface, and added a link to it in the README so users can easily find it.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [ ] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py`
- [ ] I have kept the single-file architecture (no package split)
- [ ] I have not added new dependencies without justification in the PR
      description

## Screenshots / logs (if applicable)

<!-- Attach screenshots or `moontech_*.log` snippets if this is a UI or
     download-engine change. -->
