### PR TITLE
fix: report skipped proxies and missing proxy files

### DIFF
--- a/moon_cli.py
+++ b/moon_cli.py
@@ -51,13 +51,13 @@ def _fmt_speed(mbs: float) -> str:
     return f"{mbs:.1f} MB/s" if mbs >= 1 else f"{mbs*1024:.0f} KB/s"
 
 async def run(urls: list[str], output_dir: str, n_workers: int,
-              max_dl: int, max_retries: int, proxy_path: str):
+              max_dl: int, max_retries: int, proxy_path: str, is_default_proxies: bool = False):
 
     os.makedirs(output_dir, exist_ok=True)
 
-    n_proxies = _PROXY_POOL.load(proxy_path)
-    if n_proxies:
-        print(f"[proxies] {n_proxies} loaded")
+    n_proxies, skipped = _PROXY_POOL.load(proxy_path, is_default=is_default_proxies)
+    if n_proxies or skipped:
+        print(f"[proxies] {n_proxies} loaded, {skipped} skipped")
 
     q             = asyncio.Queue()
     dl_sem        = asyncio.Semaphore(max_dl)
@@ -275,7 +275,7 @@ def main():
     ap.add_argument("--browsers", type=int, default=8,  help="Parallel extraction workers (default: 8)")
     ap.add_argument("--streams",  type=int, default=24, help="Concurrent download streams (default: 24)")
     ap.add_argument("--retries",  type=int, default=3,  help="Max retries per link (default: 3)")
-    ap.add_argument("--proxies",  default="proxies.txt", help="Proxy list file (default: proxies.txt)")
+    ap.add_argument("--proxies",  default=None, help="Proxy list file (default: proxies.txt)")
     args = ap.parse_args()
 
     if not os.path.exists(args.urls):
@@ -289,9 +289,12 @@ def main():
 
     print(f"Loaded {len(urls)} URLs from {args.urls}")
 
+    is_default_proxies = args.proxies is None
+    proxy_path = args.proxies if args.proxies is not None else "proxies.txt"
+
     try:
         asyncio.run(run(urls, args.output, args.browsers, args.streams,
-                        args.retries, args.proxies))
+                        args.retries, proxy_path, is_default_proxies))
     except KeyboardInterrupt:
         print("\nInterrupted.")
     except Exception:

--- a/moon_download.py
+++ b/moon_download.py
@@ -106,10 +106,13 @@ class ProxyPool:
         self._lock = threading.Lock()
         self._sessions: dict[str, aiohttp.ClientSession] = {}
 
-    def load(self, path: str) -> int:
+    def load(self, path: str, is_default: bool = False) -> tuple[int, int]:
         if not os.path.exists(path):
-            return 0
+            if not is_default:
+                print(f"WARNING: proxy file not found at {path}")
+            return 0, 0
         loaded = []
+        skipped = 0
         with open(path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
@@ -132,11 +135,16 @@ class ProxyPool:
                         elif len(parts) == 2:
                             ip, port = parts
                             loaded.append({"url": f"http://{ip}:{port}", "auth": None})
+                        else:
+                            skipped += 1
                 except Exception:
                     # Skip line if proxy parsing or auth formatting fails
+                    skipped += 1
                     continue
         self.proxies = loaded
-        return len(loaded)
+        if not loaded:
+            print(f"WARNING: proxy file {path} yielded 0 proxies")
+        return len(loaded), skipped
 
     def next(self) -> dict | None:
         """Round-robin proxy selection."""

--- a/moon_engine.py
+++ b/moon_engine.py
@@ -480,7 +480,7 @@ class Engine:
             captcha_wait=eff["dn_captcha"])
 
         proxy_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "proxies.txt")
-        self._proxies = _PROXY_POOL.load(proxy_path)
+        self._proxies, skipped = _PROXY_POOL.load(proxy_path, is_default=True)
 
         n, d, r = eff["workers"], eff["dl_streams"], eff["retries"]
         self.log(f"▶  {len(urls)} links  ·  {n} extractors  ·  {d} streams  ·  {r} retries  ·  {VERSION}", "info")
@@ -489,8 +489,8 @@ class Engine:
                  f"   ·   datanodes: {applied['lanes']} pages, captcha {applied['captcha_wait']}s"
                  f"{', API key' if applied['api_key'] else ''}", "dim")
         self.log(f"   chrome: {applied['chrome']}", "dim")
-        if self._proxies:
-            self.log(f"   proxies: {self._proxies} loaded — rotating per download", "info")
+        if self._proxies or skipped:
+            self.log(f"   proxies: {self._proxies} loaded, {skipped} skipped — rotating per download", "info")
         self.log(f"   stall < {STALL_MIN_MBS} MB/s  ·  grace {STALL_GRACE_S}s  ·  max {STALL_MAX_KILL} kill", "dim")
 
         self._thread = threading.Thread(

--- a/tests/test_proxy_pool.py
+++ b/tests/test_proxy_pool.py
@@ -1,0 +1,39 @@
+import pytest
+from moon_download import ProxyPool
+
+
+def test_proxy_pool_load_valid(tmp_path):
+    proxy_file = tmp_path / "proxies.txt"
+    proxy_file.write_text("1.2.3.4:8080\nuser:pass:5.6.7.8:9090\n# comment\n\n")
+    pool = ProxyPool()
+    loaded, skipped = pool.load(str(proxy_file))
+    assert loaded == 2
+    assert skipped == 0
+    assert len(pool.proxies) == 2
+
+
+def test_proxy_pool_load_skipped(tmp_path):
+    proxy_file = tmp_path / "proxies.txt"
+    proxy_file.write_text("1.2.3.4:8080\ninvalid_line\n5.6.7.8:9090\n")
+    pool = ProxyPool()
+    loaded, skipped = pool.load(str(proxy_file))
+    assert loaded == 2
+    assert skipped == 1
+
+
+def test_missing_explicit_proxy(capsys):
+    pool = ProxyPool()
+    loaded, skipped = pool.load("non_existent_file.txt", is_default=False)
+    assert loaded == 0
+    assert skipped == 0
+    captured = capsys.readouterr()
+    assert "WARNING: proxy file not found" in captured.out
+
+
+def test_missing_default_proxy(capsys):
+    pool = ProxyPool()
+    loaded, skipped = pool.load("non_existent_file.txt", is_default=True)
+    assert loaded == 0
+    assert skipped == 0
+    captured = capsys.readouterr()
+    assert "WARNING: proxy file not found" not in captured.out


### PR DESCRIPTION
### What changed
This PR fixes the silent failure modes in `--proxies` loading as described in #42. 

Specifically:
1. **Missing Files**: Added logic to emit a visible `WARNING: proxy file not found at {path}` if an explicitly passed proxy file does not exist. (If the default `proxies.txt` is missing, it still fails silently since this is the normal no-proxy state).
2. **Skipped Lines**: `ProxyPool.load()` now returns a tuple `(loaded_count, skipped_count)`. The CLI and engine both print `[proxies] {N} loaded, {S} skipped` if any lines failed to parse.
3. **Zero Proxies Loaded**: If a file exists but yields exactly 0 proxies (all lines were empty, comments, or skipped), a clear `WARNING` is printed.
4. **Shared Logic**: The exact same proxy pool loading improvements were applied to both `moon_cli.py` and `moon_engine.py` to maintain synchronization (per `CONTRIBUTING.md` rules on `ProxyPool`).
5. **Testing**: Added `tests/test_proxy_pool.py` using `pytest` and `tmp_path` to assert all warning permutations.

### Why we changed it
Previously, users could pass a misspelled path (e.g., `--proxies px.txt`) or a file with broken formatting, and the downloader would silently proceed with direct, unproxied connections. This defeated the entire security purpose of the `--proxies` flag without notifying the user. By surfacing parse counts and missing-file errors, users immediately know if their proxy setup is broken, while still preserving the fallback behavior of downloading directly.

Closes #42