### PR TITLE
docs: fix headless CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ pip install -r requirements.txt
 playwright install chromium
 python moon_bridge.py            # GUI
 python moon_bridge.py --serve    # server only, prints the URL
-python moon_cli.py <url> ... -o <folder>   # headless CLI
+python moon_cli.py --urls links.txt --output ./downloads   # headless CLI
 ```
 
 ### Just want to look at the interface?


### PR DESCRIPTION
Closes #44

The README manual block now uses the actual headless CLI interface:

```bash
python moon_cli.py --urls links.txt --output ./downloads
```

This matches the parser and `docs/CLI.md`: `--urls` points to a text file containing one URL per line, and `--output` names the destination directory. I checked the remaining `moon_cli.py` reference in the README and verified `python moon_cli.py --help`.

Validation: `python moon_cli.py --help`, `git diff --check`.
