### PR TITLE
Add --version flag to moon_cli.py, record version in CLI/engine reports

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,6 +21,7 @@ are ignored.
 | `--streams` | integer | `24` | Maximum number of concurrent download streams. |
 | `--retries` | integer | `3` | Maximum extraction attempts per URL. Network retries inside one download are separate. |
 | `--proxies` | path | `proxies.txt` | Proxy-list file to load. Missing files simply result in no proxies being loaded. |
+| `--version` | flag | — | Print the version and exit. Works even without `--urls`/`--output`. |
 
 `--urls` and `--output` are required. The parser accepts integer values for
 `--browsers`, `--streams`, and `--retries`; it does not add further CLI-side range

--- a/moon_cli.py
+++ b/moon_cli.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse, unquote
 from moon_download import (
     LAUNCH_ARGS,
     Telemetry,
+    VERSION,
     _PROXY_POOL,
     _close_sess,
     _sanitize_filename,
@@ -276,6 +277,7 @@ def main():
     ap.add_argument("--streams",  type=int, default=24, help="Concurrent download streams (default: 24)")
     ap.add_argument("--retries",  type=int, default=3,  help="Max retries per link (default: 3)")
     ap.add_argument("--proxies",  default=None, help="Proxy list file (default: proxies.txt)")
+    ap.add_argument("--version",  action="version", version=VERSION)
     args = ap.parse_args()
 
     if not os.path.exists(args.urls):

--- a/moon_download.py
+++ b/moon_download.py
@@ -267,7 +267,7 @@ class Telemetry:
             buf.write(" ".join(str(p) for p in parts) + "\n")
 
         W("=" * 72)
-        W("MOONTECH CLI  --  PERFORMANCE LOG")
+        W(f"MOONTECH CLI {VERSION}  --  PERFORMANCE LOG")
         W("=" * 72)
         W(f"Duration : {int(el//60)}m {int(el%60)}s")
         if ok_r:
@@ -291,6 +291,7 @@ class Telemetry:
         )
         with open(jp, "w", encoding="utf-8") as f:
             json.dump({
+                "version": VERSION,
                 "duration_s": round(el, 2),
                 "ok": len(ok_r),
                 "fail": len(recs) - len(ok_r),
@@ -388,6 +389,7 @@ class Telemetry:
         with open(jp, "w", encoding="utf-8") as f:
             json.dump({
                 "session": {
+                    "version": VERSION,
                     "start": datetime.datetime.now().isoformat(),
                     "duration_s": round(el, 2),
                     "config": self.cfg,


### PR DESCRIPTION
Fixes #60 (commented there before starting, per CONTRIBUTING.md).

## What changed

1. **`moon_cli.py`**: added `--version` via `argparse`'s built-in `action="version"`, importing the existing `VERSION` constant from `moon_download.py` (no second copy). Since `action="version"` short-circuits before argparse's required-argument check, it works without `--urls`/`--output`.
2. **`moon_download.py`**: `Telemetry._save_cli` now includes `VERSION` in its log header and as a `"version"` field in its JSON report (previously had neither). `_save_engine`'s log header already had it; added the matching `"version"` field to its JSON report for parity.
3. **`docs/CLI.md`**: documented the new flag in the arguments table.

One version constant (`moon_download.py:23`), imported everywhere it's used — no circular-import issue since `moon_cli.py` already imports from `moon_download`.

## Verification

- `pytest tests/ -q` — 11 passed.
- `python moon_cli.py --version` → prints `v2.0`, exit 0, with and without other args.
- `python moon_cli.py` (no args) → still correctly errors requiring `--urls`/`--output`, exit 2 (no regression).
- Direct smoke test of `Telemetry.save()` for both `flavor="cli"` and `flavor="engine"`, confirming the generated `.log` header and `.json` field actually contain the version (not just eyeballing the diff):
  ```
  CLI json version field: v2.0
  CLI log header line: MOONTECH CLI v2.0  --  PERFORMANCE LOG
  Engine json version field: v2.0
  Engine log header line: MOONTECH v2.0  —  PERFORMANCE LOG
  ```

All acceptance criteria from the issue are met.

## AI Usage

Implemented with Claude Code (Claude Sonnet). Scope: the three files above only; no changes to extraction, download, or GUI logic.