### PR TITLE
docs(cli): fix stale --proxies row and document the actual warning behavior

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,12 +20,22 @@ are ignored.
 | `--browsers` | integer | `8` | Number of parallel extraction workers. Despite the name, it does not start that many browsers: datanodes uses one shared Chrome instance. |
 | `--streams` | integer | `24` | Maximum number of concurrent download streams. |
 | `--retries` | integer | `3` | Maximum extraction attempts per URL. Network retries inside one download are separate. |
-| `--proxies` | path | `proxies.txt` | Proxy-list file to load. Missing files simply result in no proxies being loaded. |
+| `--proxies` | path | `proxies.txt` | Proxy-list file to load. A missing file, or one that yields no usable proxies, prints a warning — except the implicit default (`proxies.txt` when `--proxies` is omitted), whose absence stays silent as the normal no-proxy state. |
 | `--version` | flag | — | Print the version and exit. Works even without `--urls`/`--output`. |
 
 `--urls` and `--output` are required. The parser accepts integer values for
 `--browsers`, `--streams`, and `--retries`; it does not add further CLI-side range
 validation.
+
+The parser's actual default for `--proxies` is unset (`None`); `proxies.txt` is the
+effective fallback path applied afterward. That distinction is what lets the CLI tell
+"you didn't ask for proxies" (silent) apart from "you asked for a proxy file and it's
+missing or empty":
+
+- an explicitly passed path that doesn't exist: `WARNING: proxy file not found at {path}`
+- a file that exists but yields no usable proxies: `WARNING: proxy file {path} yielded 0 proxies`
+- the implicit default path missing: no warning
+- whenever any proxies load or lines get skipped: `[proxies] {n} loaded, {s} skipped`
 
 ## Examples
 


### PR DESCRIPTION
Fixes #62 (commented there before starting, per CONTRIBUTING.md).

## What changed

Only `docs/CLI.md`. Rewrote the `--proxies` row (was describing pre-#48 behavior) and added a short prose block distinguishing the four actual cases, verified directly against `ProxyPool.load()` (`moon_download.py:109-147`) and its call site in `run()` (`moon_cli.py:59-61`) rather than taking the issue's summary at face value:

- an explicitly passed path that doesn't exist → `WARNING: proxy file not found at {path}`
- a file that exists but yields no usable proxies → `WARNING: proxy file {path} yielded 0 proxies` (this one fires regardless of default vs. explicit)
- the implicit default (`proxies.txt`) missing → silent, the normal no-proxy state
- whenever anything loads or gets skipped → `[proxies] {n} loaded, {s} skipped`

Also noted that the parser's actual default for `--proxies` is `None` (`moon_cli.py:278`), with `proxies.txt` applied as a fallback afterward (`moon_cli.py:294-295`) — that's what makes the silent-vs-warning distinction possible in the first place, so the table's shown default isn't literally what the parser has.

## Checked, not just the one row

- The GUI-comparison table row at L113 (`--proxies` / — / "The CLI reads a proxy-list file; it is not a GUI panel setting.") — still accurate, makes no claim about warning behavior. Left as-is.
- What #48 and #54 actually touched: #48 changed `moon_cli.py`, `moon_download.py`, and `moon_engine.py` (the proxy-warning behavior itself); #54 was comment-only exception annotations, no behavior change. Nothing else in `docs/CLI.md` was affected by either.

## AI Usage

Implemented with Claude Code (Claude Sonnet). Scope: `docs/CLI.md` only, as the issue's acceptance criteria required.