### PR TITLE
docs(authors): fix the dead NanoRisk6 link and cite the right reference

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,7 +13,7 @@ first contribution:
 |:--|:--|
 | [@kushin25](https://github.com/kushin25) | `docs/CLI.md`, the CLI reference (#37) |
 | [@pollychen-lab](https://github.com/pollychen-lab) | moved the no-Chrome regression into a pytest suite (#38), then moved the download engine into a shared `moon_download.py` (#41) |
-| [@NanoRisk6](https://github.com/NanoRisk6) | pointed the documented verification commands at `pytest tests/` after the test move (#43) |
+| NanoRisk6 — *account no longer on GitHub* | pointed the documented verification commands at `pytest tests/` across six files after the test move (issue #43, commit `f9f8f74`) |
 | [@AdvaitVarhade](https://github.com/AdvaitVarhade) | made `--proxies` report missing files and skipped lines instead of failing silently (#48); narrowed `native_dialog`'s exception handling and documented four deliberate swallows (#54) |
 | [@Moferanoluwa](https://github.com/Moferanoluwa) | added `--version` and made both report flavours record which build wrote them (#61); corrected the `--proxies` documentation that #48 had made stale (#63) |
 


### PR DESCRIPTION
The `@NanoRisk6` row linked to `github.com/NanoRisk6`, which now returns 404 — the account was deleted or renamed some time after 31 July.

**The contribution is real and stays credited.** Commit `f9f8f74` pointed the documented verification commands at `pytest tests/` across six files (`CONTRIBUTING.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/FAQ.md`, `docs/PROVIDERS.md`, `docs/TROUBLESHOOTING.md`) after the pytest move. Only the link is dead, so the name is now plain text with a note.

Second fix in the same row: it cited "#43" in a column where every other row cites a merged pull request. #43 is the *issue* that motivated the work, not a PR, so it is now labelled as one and the commit is cited alongside it.

No other rows touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)