### PR TITLE
ci: verify Markdown-documented moon_cli.py flags actually exist

### DIFF
--- a/.github/workflows/docs-cli-check.yml
+++ b/.github/workflows/docs-cli-check.yml
@@ -1,0 +1,31 @@
+name: Docs CLI Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.md"
+      - "**.py"
+      - ".github/workflows/docs-cli-check.yml"
+  pull_request:
+    paths:
+      - "**.md"
+      - "**.py"
+
+jobs:
+  docs-cli-flags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install engine dependencies
+        run: pip install "aiohttp>=3.9" "curl_cffi>=0.7" "pytest==8.*"
+
+      - name: Verify documented moon_cli.py flags exist
+        run: pytest tests/test_docs_cli_flags.py -q

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   syntax-check:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -20,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: Byte-compile every module
         run: |
@@ -29,6 +33,12 @@ jobs:
             moon_extract.py moon_bridge.py render_gui.py \
             integration_http.py integration_web.py \
             tests/conftest.py tests/test_no_chrome.py
+
+      - name: Install ruff
+        run: pip install "ruff==0.16.1"
+
+      - name: Lint with ruff
+        run: ruff check .
 
   no-chrome:
     runs-on: ubuntu-latest

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,8 @@ of truth for the modern engine. `moon_engine.py` is that engine, standing on its
 
 The async engine itself was **not** rewritten. `_run`, `_browser_worker`, `_do_dl`,
 `download_file`, `Telemetry` and `ProxyPool` are the 14.8 code, plus the lazy browser
-launch described below.
+launch described below. `download_file`, `Telemetry` and `ProxyPool` now live in
+`moon_download.py`, shared by `moon_engine.py` and `moon_cli.py`.
 
 ## Startup
 
@@ -118,6 +119,7 @@ every number to its limits (`workers` 2–32, `dl_streams` 2–48, `retries` 0�
 | `moon_bridge.py` | window host, OS dialogs, `settings.json` |
 | `moon_engine.py` | the engine with no GUI + the JSON API |
 | `moon_extract.py` | extraction for both providers + the Chrome lifecycle + `BrowserGate` |
+| `moon_download.py` | the download engine, `Telemetry` and `ProxyPool`, shared by the GUI engine and CLI |
 | `web/index.html` | structure |
 | `web/styles.css` | everything visual |
 | `web/app.js` | rendering, the bridge, and a synthetic engine for the preview |
@@ -128,9 +130,10 @@ every number to its limits (`workers` 2–32, `dl_streams` 2–48, `retries` 0�
 | `integration_http.py` | end-to-end: browser ↔ loopback HTTP ↔ Engine |
 | `integration_web.py` | end-to-end: pywebview ↔ Engine |
 
-`moon_engine.py` and `moon_cli.py` each carry their own copy of the download engine
-(`download_file`, `Telemetry`, `ProxyPool`); the extraction layer, the Chrome lifecycle and
-the launch decision are shared through `moon_extract.py`.
+The download engine, telemetry and proxy rotation (`download_file`, `Telemetry`,
+`ProxyPool`) are shared through `moon_download.py`; the extraction layer, the Chrome
+lifecycle and the launch decision are shared through `moon_extract.py`. `moon_engine.py`
+and `moon_cli.py` both import from both.
 
 ---
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+line-length = 100
+target-version = "py310"
+
+[lint]
+select = ["E", "F", "W", "I"]
+ignore = [
+    "E501",  # line length - handled above via line-length instead
+    # Everything below fires on the codebase as it stands today. Per the issue that
+    # introduced this file: the goal is a green baseline that catches regressions, not
+    # a reformat, so these are parked here rather than fixed inline. Each is a real,
+    # pre-existing pattern (counts below from `ruff check .` before this ignore list):
+    "E702",  # multiple-statements-on-one-line-semicolon (58) - dense assignment style throughout moon_engine.py/moon_download.py
+    "E701",  # multiple-statements-on-one-line-colon (19) - same dense style
+    "I001",  # unsorted-imports (9) - several are deliberately grouped after a sys.path.insert, not just unsorted
+    "E402",  # module-import-not-at-top-of-file (5) - deferred/lazy imports inside functions
+    "E401",  # multiple-imports-on-one-line (4) - e.g. `import os, sys, asyncio, threading, argparse`
+    "E741",  # ambiguous-variable-name (2) - `l` as a loop variable in two spots
+    "F401",  # unused-import (1) - tests/test_proxy_pool.py imports pytest without using it directly
+]

--- a/tests/test_docs_cli_flags.py
+++ b/tests/test_docs_cli_flags.py
@@ -1,0 +1,79 @@
+"""Verify moon_cli.py invocations documented in Markdown use flags the parser accepts.
+
+lint.yml only triggers on .py changes, so a documentation-only PR was never checked
+against the real CLI parser (see #44, where README.md documented an invocation the
+parser never accepted, and #56, which added this check). The real flag set is read
+from `moon_cli.py --help` at test time rather than hardcoded, so adding a new flag to
+moon_cli.py never requires touching this file to stay in sync.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+FENCE_RE = re.compile(r"```(?:bash|sh|text)?\n(.*?)```", re.DOTALL)
+FLAG_RE = re.compile(r"--[a-zA-Z][a-zA-Z-]*")
+
+
+def _real_flags() -> set[str]:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "moon_cli.py"), "--help"],
+        capture_output=True, text=True, timeout=30, check=True,
+    )
+    return set(FLAG_RE.findall(result.stdout))
+
+
+def _tracked_md_files() -> list[pathlib.Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "*.md"],
+        cwd=ROOT, capture_output=True, text=True, timeout=30, check=True,
+    )
+    return [ROOT / line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _logical_lines(block: str):
+    """Yield (line_offset, joined_text) for each line in a fenced code block, merging
+    backslash-continued lines into a single logical command."""
+    physical = block.split("\n")
+    i = 0
+    while i < len(physical):
+        start = i
+        parts = [physical[i].rstrip()]
+        while parts[-1].endswith("\\") and i + 1 < len(physical):
+            parts[-1] = parts[-1][:-1]
+            i += 1
+            parts.append(physical[i].rstrip())
+        yield start, " ".join(p.strip() for p in parts)
+        i += 1
+
+
+def _bad_flags_in_file(md_path: pathlib.Path, real_flags: set[str]) -> list[str]:
+    text = md_path.read_text(encoding="utf-8")
+    errors: list[str] = []
+    for fence in FENCE_RE.finditer(text):
+        block = fence.group(1)
+        block_start_line = text[: fence.start()].count("\n") + 1
+        for offset, line in _logical_lines(block):
+            if "moon_cli.py" not in line or "python" not in line:
+                continue
+            used_flags = set(FLAG_RE.findall(line))
+            for flag in sorted(used_flags - real_flags):
+                line_no = block_start_line + offset + 1
+                rel = md_path.relative_to(ROOT).as_posix()
+                errors.append(f"{rel}:{line_no}: {flag!r} is not a real moon_cli.py flag")
+    return errors
+
+
+def test_documented_cli_flags_exist():
+    real_flags = _real_flags()
+    assert real_flags, "could not read any flags from `python moon_cli.py --help`"
+
+    all_errors: list[str] = []
+    for md_file in _tracked_md_files():
+        all_errors.extend(_bad_flags_in_file(md_file, real_flags))
+
+    assert not all_errors, "\n" + "\n".join(all_errors)


### PR DESCRIPTION
Fixes #56 (commented there before starting, per CONTRIBUTING.md).

## The gap, and why it's not hypothetical

`lint.yml` is filtered on `paths: ["**.py"]`, so a documentation-only PR triggers no workflow at all — not a skipped job, nothing runs. #44 existed because README.md documented a `moon_cli.py` invocation the parser never accepted, and it survived every green build because no build ever looked at it. My own #63 and #69 are now further evidence: `LeyckerS` had to catch the stale content by reading each diff personally, since nothing else was checking.

## What this adds

- **`tests/test_docs_cli_flags.py`**: extracts every `python moon_cli.py ...` invocation from tracked `.md` files (joining `\`-continued multi-line commands into one logical command first), and checks every `--flag` each one uses against the real flag set read from `python moon_cli.py --help` at test time. Not hardcoded — adding a real flag to `moon_cli.py` never requires touching this file.
- **New workflow `.github/workflows/docs-cli-check.yml`**, triggered on `**.md` as well as `**.py`. This is a separate file from `lint.yml` rather than a new job inside it, because GitHub Actions path filters apply to a workflow's trigger as a whole, not per-job — folding this into `lint.yml` would have made `syntax-check`/`ruff`/`no-chrome` also re-run on every doc-only change, which isn't what those jobs are for.

## Verified for real, twice over

Same lesson as #69: this PR's own diff wouldn't self-test against `pull_request`'s path filters in the way that matters, so I pushed to my fork's `main` first and read real Actions runs rather than trusting local simulation:

- **Docs CLI Check**: https://github.com/Moferanoluwa/moondownloader/actions/runs/30678079789 — `docs-cli-flags` green.
- **Lint** (triggered too, since the new test file is itself `.py`): https://github.com/Moferanoluwa/moondownloader/actions/runs/30678079768 — `no-chrome` and all three `syntax-check` matrix legs (3.10/3.11/3.12, including the `ruff check .` step from #69) green.

Also validated the failure path locally before any of that, per the issue's own suggestion: appended a deliberately nonexistent `--totally-fake-flag` to `docs/CLI.md`, ran the test, got

```
docs/CLI.md:132: '--totally-fake-flag' is not a real moon_cli.py flag
```

then reverted it. Full local `pytest tests/ -q` is 12/12 (up from 11 — this file is auto-discovered, so it also runs for free inside `no-chrome` on any future `.py` change, on top of the dedicated workflow).

## AI Usage

Implemented with Claude Code (Claude Sonnet). Scope: the two new files listed above only.