### PR TITLE
cleanup: annotate the 3 except Exception: handlers in moon_engine.py

### DIFF
--- a/moon_engine.py
+++ b/moon_engine.py
@@ -263,6 +263,8 @@ class Engine:
                             async with tasks_lock: all_tasks.append(t)
                             success = True
                 except Exception as e:
+                    # One URL's extraction/scheduling failed for any reason (network,
+                    # parsing, Chrome/CDP); the worker loop must keep serving the queue.
                     rec.notes.append(f"exception: {e}")
                     self.log(f"    ✗  {e}", "fail")
 
@@ -368,7 +370,10 @@ class Engine:
             lp, jp = telem.save(base)
             self.log(f"📊  {os.path.basename(lp)}", "info")
             self.log(f"📊  {os.path.basename(jp)}", "info")
-        except Exception as e:
+        except (OSError, TypeError) as e:
+            # OSError: can't open/write the report files (permissions, disk full, bad
+            # path). TypeError: json.dump choking on a non-serializable field. The run's
+            # downloads already completed; a report-write failure shouldn't crash finalize.
             self.log(f"⚠  Log save error: {e}", "warn")
 
         if output_links and mode == "links":
@@ -503,6 +508,8 @@ class Engine:
         try:
             asyncio.run(self._run(urls, n, d, r))
         except Exception:
+            # Top-level guard for a background thread: anything that escapes _run()
+            # would otherwise vanish silently instead of surfacing to the GUI/CLI.
             self.log(f"✗  engine crash: {traceback.format_exc(limit=3)}", "fail")
             self._on_done()
 


### PR DESCRIPTION
Slice D of #46 (commented there before starting, per CONTRIBUTING.md) — the `moon_engine.py` portion; `moon_extract.py`'s slices A/B/C are @AdvaitVarhade's per the latest count in the issue.

## The three handlers, per the #54 standard

- **L265** (per-URL extraction/scheduling inside the worker loop) — stays broad, with a comment. Any failure processing one URL (network, parsing, Chrome/CDP) must not kill the worker loop, which is still serving the rest of the queue.
- **L371** (writing the telemetry report at run end) — narrowed to `(OSError, TypeError)`. `OSError` covers file open/write failures (permissions, disk full, bad path); `TypeError` covers `json.dump` choking on a non-serializable field. The run's downloads have already completed by this point, so logging a warning instead of propagating is correct — just not for literally any exception.
- **L505** (`_guarded_run`'s top-level try around `asyncio.run` in a thread) — stays broad, with a comment. The function's own docstring already explains why ("an escaping exception would vanish silently"); added the same reasoning at the `except` clause itself to match how #54 annotated its broad catches inline, not just at the function level.

## Verification

- `python -m py_compile moon_engine.py` — clean.
- `ruff check moon_engine.py` — clean, no new findings from the `#69` baseline.
- `pytest tests/ -q` — 11/11, no regression. Checked first that nothing in `tests/` exercises `telem.save`'s exception path, so narrowing that one carried no test-breakage risk.

## AI Usage

Implemented with Claude Code (Claude Sonnet). Scope: `moon_engine.py` only, the three handlers listed in the issue's slice D.