### PR TITLE
fix: freeze elapsed-time clock when a run finishes

### DIFF
--- a/moon_engine.py
+++ b/moon_engine.py
@@ -115,6 +115,7 @@ class Engine:
         self._dls        = 0
         self._bytes_acc  : collections.deque = collections.deque(maxlen=200000)
         self._t0         = 0.0
+        self._t_end      = 0.0
         self._proxies    = 0
 
         # Live FileRecord registry: the GUI reads these objects every snapshot,
@@ -390,6 +391,7 @@ class Engine:
             self._running = False
             self._stop_flag = False
             self._state = "done"
+            self._t_end = time.monotonic()
 
     def scan_tmp(self) -> int:
         folder = self._cfg["out_folder"]
@@ -467,6 +469,7 @@ class Engine:
             self._ok = 0; self._fail = 0; self._kills = 0
             self._browsers = 0; self._dls = 0
             self._bytes_acc.clear(); self._t0 = time.monotonic()
+            self._t_end = 0.0
             self._tracked.clear()
         with self._log_lock:
             self._log_ring.clear(); self._log_total = 0
@@ -558,6 +561,7 @@ class Engine:
             state    = self._state
             running  = self._running
             t0       = self._t0
+            t_end    = self._t_end
             url_done = self._url_done; url_tot = self._url_total
             dl_done  = self._dl_done;  dl_tot  = self._dl_total
             ok       = self._ok; fail = self._fail
@@ -580,7 +584,7 @@ class Engine:
         else:
             eta = 0.0
 
-        el = (now - t0) if t0 else 0.0
+        el = (t_end - t0) if t_end else ((now - t0) if t0 else 0.0)
         # No phase sentence here on purpose: the GUI owns wording and language,
         # so the engine ships numbers and a stage name instead of prose.
         if not running and state == "idle":

--- a/tests/test_elapsed_clock.py
+++ b/tests/test_elapsed_clock.py
@@ -1,0 +1,42 @@
+import time
+from moon_engine import Engine
+
+
+def test_elapsed_freezes_after_done():
+    engine = Engine()
+    engine._t0 = time.monotonic()
+    engine._on_done()
+
+    first = engine.snapshot()["metrics"]["elapsed_s"]
+    time.sleep(0.2)
+    second = engine.snapshot()["metrics"]["elapsed_s"]
+
+    assert first == second
+
+
+def test_elapsed_resets_on_new_run(monkeypatch, tmp_path):
+    engine = Engine()
+    engine._t0 = time.monotonic()
+    engine._on_done()
+    time.sleep(0.2)
+
+    # Swap out the real extraction/download path so start() doesn't touch
+    # the network or a browser — only the state-reset logic is under test.
+    monkeypatch.setattr(engine, "_guarded_run", lambda *a, **k: None)
+
+    result = engine.start({"links": ["https://example.com/f1"], "out_folder": str(tmp_path)})
+    assert result.get("ok") is True
+
+    elapsed_after_restart = engine.snapshot()["metrics"]["elapsed_s"]
+    assert elapsed_after_restart < 0.2
+
+
+def test_elapsed_still_live_while_running():
+    engine = Engine()
+    engine._t0 = time.monotonic()
+
+    first = engine.snapshot()["metrics"]["elapsed_s"]
+    time.sleep(0.2)
+    second = engine.snapshot()["metrics"]["elapsed_s"]
+
+    assert second > first


### PR DESCRIPTION
Closes #58

   Adds `_t_end` alongside `_t0`: recorded in `_on_done()`, reset in `start()`,
   and used in `snapshot()` to freeze `elapsed_s` once a run has ended instead
   of letting it keep counting from `now - t0`.

   Added tests/test_elapsed_clock.py covering:
   - elapsed_s stays frozen after a run finishes
   - elapsed_s resets when a new run starts
   - elapsed_s still increases while a run is in progress

   Verified with `python -m pytest tests/ -q` — 14 passed.