### PR TITLE
ci: derive compileall file list from git ls-files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - "**.py"
+      - ".github/workflows/lint.yml"
 
 jobs:
   syntax-check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,12 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Byte-compile every module
-        run: |
-          python -m compileall -q \
-            moon_engine.py moon_cli.py \
-            moon_extract.py moon_bridge.py render_gui.py \
-            integration_http.py integration_web.py \
-            tests/conftest.py tests/test_no_chrome.py
+        run: git ls-files '*.py' | xargs python -m compileall -q
 
       - name: Install ruff
         run: pip install "ruff==0.16.1"


### PR DESCRIPTION
Closes #74

## What
`lint.yml` byte-compiled an explicit hand-maintained list of `.py` files, which drifted — `moon_download.py` (the most-depended-on module: `download_file`, `Telemetry`, `ProxyPool`), `tests/test_proxy_pool.py` and `tests/test_docs_cli_flags.py` were never compiled.

Replace the list with a derived one so it can never drift again:

```yaml
run: git ls-files '*.py' | xargs python -m compileall -q
```

Only tracked files are included — no `__pycache__`, venv or scratch files.

## Verification (acceptance criteria)
- `lint.yml` no longer contains a hand-written list of `.py` files ✅
- New command compiles all 13 tracked `.py` files, exit 0 ✅
- Per the issue: I deliberately introduced a syntax error into `moon_download.py` locally — the new command **fails** (exit 123), while the old hand-maintained list **passed** (exit 0), confirming the hole. Reverted before committing.
- Job runs on the existing 3-version matrix (3.10/3.11/3.12) unchanged.

One file touched: `.github/workflows/lint.yml` (+1 −6).
- Bonus: added \`.github/workflows/lint.yml\` to the \`pull_request\` path filter — otherwise this PR (workflow-only change) would never trigger CI, and the "job passes on all three matrix versions" criterion could not be verified.
