### PR TITLE
fix(ci): derive compileall file list instead of hardcoding it

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,12 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Byte-compile every module
-        run: |
-          python -m compileall -q \
-            moon_engine.py moon_cli.py \
-            moon_extract.py moon_bridge.py render_gui.py \
-            integration_http.py integration_web.py \
-            tests/conftest.py tests/test_no_chrome.py
+        run: git ls-files '*.py' | xargs python -m compileall -q
 
       - name: Install ruff
         run: pip install "ruff==0.16.1"


### PR DESCRIPTION
Fix the #74 issue: change the old compile instruction in `lint.yml` that misses files to one that iterates over all `.py` files. I broke `moon_download` and confirmed it does error (and I've restored `moon_download` to its original state).

Compile error:
```
*** Error compiling 'moon_download.py'...
  File "moon_download.py", line 24
    def 关注塔菲喵()：
               ^
SyntaxError: invalid character '：' (U+FF1A)
```
Exit code: 123