### PR TITLE
chore(gitignore): ignore settings.json, which holds the API key in clear text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ failed_links.txt
 proxies.txt
 logo.png
 
+# Written by the GUI on every settings change. Holds the datanodes API key
+# in clear text and the full pasted link list -- never commit it.
+settings.json
+
 # Downloaded media (safety net if run from repo dir)
 *.rar
 *.zip


### PR DESCRIPTION
`moon_bridge.py` writes `settings.json` on every settings change. It contains `dn_apikey` in clear text and the full pasted link list.

It was the **only** user-generated file not ignored — `moontech_*.log`, `moontech_*.json`, `proxies.txt` and `*.tmp` were all already covered. Being untracked is not protection: a single `git add .` in a clone where the app had been run would have committed a live credential.

Checked before opening this: the key does **not** appear in the current tree and `git log --all -S` finds it in **zero** commits, so nothing needs scrubbing — this only closes the door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)