### PR TITLE
test: catch short flags in CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ pip install -r requirements.txt
 playwright install chromium
 python moon_bridge.py            # GUI
 python moon_bridge.py --serve    # server only, prints the URL
-python moon_cli.py <url> ... -o <folder>   # headless CLI
+python moon_cli.py --urls links.txt --output ./downloads   # headless CLI
 ```
 
 ### Just want to look at the interface?

--- a/tests/test_docs_cli_flags.py
+++ b/tests/test_docs_cli_flags.py
@@ -16,7 +16,7 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 FENCE_RE = re.compile(r"```(?:bash|sh|text)?\n(.*?)```", re.DOTALL)
-FLAG_RE = re.compile(r"--[a-zA-Z][a-zA-Z-]*")
+FLAG_RE = re.compile(r"(?<!-)--[a-zA-Z][a-zA-Z-]*|(?<!-)-[a-zA-Z](?![a-zA-Z-])")
 
 
 def _real_flags() -> set[str]:


### PR DESCRIPTION
## Description

Closes #94.

Extends the Markdown CLI docs guard so it checks documented short flags against the real `moon_cli.py --help` output too. The current README example used `-o`, which argparse does not accept; I updated that example to the long flags so the stricter guard is green on `main` even before #53 lands.

I did not add positional-argument validation in this PR; this stays scoped to the short-flag gap described in #94.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [x] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py` (not applicable; docs/test only)
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR
      description

## Test evidence

RED:

- `python -m pytest tests/test_docs_cli_flags.py -q` failed as expected after broadening the flag regex: `README.md:147: '-o' is not a real moon_cli.py flag`

GREEN:

- `python -m pytest tests/test_docs_cli_flags.py -q` → 1 passed
- `python -m pytest tests/ -q` → 16 passed
- `git diff --check` → passed

## Screenshots / logs (if applicable)

Not applicable.
