### PR TITLE
test: validate short CLI flags in Markdown docs (closes #94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ pip install -r requirements.txt
 playwright install chromium
 python moon_bridge.py            # GUI
 python moon_bridge.py --serve    # server only, prints the URL
-python moon_cli.py <url> ... -o <folder>   # headless CLI
+python moon_cli.py --urls links.txt --output ./downloads   # headless CLI
 ```
 
 ### Just want to look at the interface?

--- a/tests/test_docs_cli_flags.py
+++ b/tests/test_docs_cli_flags.py
@@ -16,7 +16,7 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 FENCE_RE = re.compile(r"```(?:bash|sh|text)?\n(.*?)```", re.DOTALL)
-FLAG_RE = re.compile(r"--[a-zA-Z][a-zA-Z-]*")
+FLAG_RE = re.compile(r"(?<![\w-])--?[a-zA-Z][a-zA-Z-]*")
 
 
 def _real_flags() -> set[str]:


### PR DESCRIPTION
## Summary

Extends `tests/test_docs_cli_flags.py` to validate short CLI options (single-dash flags like `-o`) against the parser's actual flag set output from `moon_cli.py --help`.

- Updated `FLAG_RE` in `tests/test_docs_cli_flags.py` using negative lookbehind `r"(?<![\w-])--?[a-zA-Z][a-zA-Z-]*"` to match both short and long flags without false positives.
- Corrected line 147 of `README.md` which contained invalid CLI invocation syntax (`-o`).

Closes #94.

## Verification
- Verified `pytest tests/test_docs_cli_flags.py` fails on `README.md:147` before correction with `AssertionError: README.md:147: '-o' is not a real moon_cli.py flag`.
- Verified all 16 unit tests pass after updating `README.md:147`.
- Verified `ruff check` passes.
