### PR TITLE
docs: cut v2.1, record #53 and #104, credit @tomatotomata and @kocaemre

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,8 @@ first contribution:
 | [@RubenSanosh](https://github.com/RubenSanosh) | froze the elapsed-time clock when a run finishes, so the GUI stops counting after the last file lands (#73) |
 | [@darlenepolek](https://github.com/darlenepolek) | derived the CI byte-compile list from `git ls-files` so it can no longer drift, and made the lint workflow watch its own file (#77) |
 | [@XEDAB](https://github.com/XEDAB) | made a discarded partial download say so, instead of silently restarting a multi-gigabyte transfer when the server ignores a resume request (#98) |
+| [@tomatotomata](https://github.com/tomatotomata) | corrected the headless CLI example in `README.md`, which documented positional URLs and a `-o` flag the parser never accepted (#53) |
+| [@kocaemre](https://github.com/kocaemre) | taught the documentation guard to check single-dash flags, so it now catches the line it was written for (#104) |
 
 Dependabot handles the dependency and action bumps.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1] — 2026-08-01
+
 ### Added
 - **CI runs on Python 3.10, 3.11 and 3.12, and lints with `ruff`.** The matrix uses
   `fail-fast: false` so one version failing still reports the others. `ruff.toml` selects
@@ -45,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   change from here on, and the two copies can no longer drift apart
 
 ### Fixed
+- The headless CLI example in `README.md` documented `python moon_cli.py <url> ... -o <folder>`:
+  positional URLs the parser never accepted, and a `-o` short flag that does not exist. It now
+  reads `--urls` / `--output`, which are the real flags and both required (#53, @tomatotomata)
+- **The documentation guard could not see the line it was written to catch.** `FLAG_RE` in
+  `tests/test_docs_cli_flags.py` matched only `--long` flags, so the bogus `-o` above passed
+  every check. It now validates single-dash flags against the parser as well (#104, @kocaemre)
 - **A partial download was discarded in silence.** When a server answers `200` instead of
   `206` it is refusing the resume request, and the code correctly restarts from zero — but
   said nothing, so a multi-gigabyte transfer appeared to begin again for no reason. The


### PR DESCRIPTION
Bookkeeping plus the version cut. @tomatotomata and @kocaemre are the eighth and ninth outside contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)