### PR TITLE
fix: fail unsupported hosts without retrying

### DIFF
--- a/moon_cli.py
+++ b/moon_cli.py
@@ -32,6 +32,9 @@ from moon_extract import (                       # noqa: E402
     HAVE_CURL_CFFI,
     DN_API_KEY,
     DN_LANES,
+    DATANODES_HOST,
+    FUCKINGFAST_HOST,
+    SUPPORTED_HOSTS,
 )
 
 if DN_API_KEY:
@@ -172,9 +175,10 @@ async def run(urls: list[str], output_dir: str, n_workers: int,
             print(f"  -> {filename[:60]}{suffix}")
 
             success = False
+            unsupported = False
             try:
                 parsed = urlparse(url)
-                if "fuckingfast.co" in parsed.netloc:
+                if FUCKINGFAST_HOST in parsed.netloc:
                     link = await extract_fuckingfast(url)
                     rec.extract_s = time.monotonic() - t_start
                     if not link:
@@ -186,7 +190,7 @@ async def run(urls: list[str], output_dir: str, n_workers: int,
                         t = asyncio.create_task(_task())
                         async with tasks_lock: all_tasks.append(t)
                         success = True
-                elif "datanodes.to" in parsed.netloc:
+                elif DATANODES_HOST in parsed.netloc:
                     # API key set -> single JSON GET, no browser, no captcha.
                     # get_browser() is where Chrome is actually launched, so a
                     # batch with no datanodes link never opens one. After that
@@ -204,10 +208,18 @@ async def run(urls: list[str], output_dir: str, n_workers: int,
                         t = asyncio.create_task(_task())
                         async with tasks_lock: all_tasks.append(t)
                         success = True
+                else:
+                    host = parsed.hostname or parsed.netloc or "(missing host)"
+                    rec.notes.append(f"unsupported host: {host}")
+                    print(
+                        f"  [fail] unsupported host: {host} — supported: "
+                        f"{', '.join(SUPPORTED_HOSTS)}"
+                    )
+                    unsupported = True
             except Exception as e:
                 print(f"  [error] {e}")
 
-            if not success and not is_re and attempt < max_retries:
+            if not success and not unsupported and not is_re and attempt < max_retries:
                 backoff = min(2**(attempt-1), 6)
                 print(f"  [retry in {backoff}s]")
                 await asyncio.sleep(backoff)

--- a/moon_engine.py
+++ b/moon_engine.py
@@ -69,6 +69,9 @@ from moon_extract import (                       # noqa: E402
     HAVE_CURL_CFFI,
     DN_API_KEY,
     DN_LANES,
+    DATANODES_HOST,
+    FUCKINGFAST_HOST,
+    SUPPORTED_HOSTS,
 )
 import moon_extract as _moon_extract            # noqa: E402
 
@@ -216,9 +219,10 @@ class Engine:
                 self._track(rec)
 
                 success = False
+                unsupported = False
                 try:
                     parsed = urlparse(url)
-                    if "fuckingfast.co" in parsed.netloc:
+                    if FUCKINGFAST_HOST in parsed.netloc:
                         link = await extract_fuckingfast(url)
                         rec.extract_s = time.monotonic()-t_start
                         if not link:
@@ -237,7 +241,7 @@ class Engine:
                             my_tasks.append(t)
                             async with tasks_lock: all_tasks.append(t)
                             success = True
-                    elif "datanodes.to" in parsed.netloc:
+                    elif DATANODES_HOST in parsed.netloc:
                         # API key set -> single JSON GET, no browser, no captcha.
                         # get_browser() is where Chrome is actually launched, so a
                         # batch with no datanodes link never opens one. After that
@@ -263,13 +267,23 @@ class Engine:
                             my_tasks.append(t)
                             async with tasks_lock: all_tasks.append(t)
                             success = True
+                    else:
+                        host = parsed.hostname or parsed.netloc or "(missing host)"
+                        rec.notes.append(f"unsupported host: {host}")
+                        self.log(
+                            f"    ✗  unsupported host: {host} — supported: "
+                            f"{', '.join(SUPPORTED_HOSTS)}",
+                            "fail",
+                        )
+                        unsupported = True
                 except Exception as e:
                     # One URL's extraction/scheduling failed for any reason (network,
                     # parsing, Chrome/CDP); the worker loop must keep serving the queue.
                     rec.notes.append(f"exception: {e}")
                     self.log(f"    ✗  {e}", "fail")
 
-                if not success and not is_re and attempt < max_retries and not self._get("_stop_flag"):
+                if (not success and not unsupported and not is_re and attempt < max_retries
+                        and not self._get("_stop_flag")):
                     backoff = min(2**(attempt-1), 6)
                     self.log(f"    ↻  retry in {backoff}s", "warn")
                     await asyncio.sleep(backoff)

--- a/moon_extract.py
+++ b/moon_extract.py
@@ -49,6 +49,10 @@ from urllib.parse import urlparse, unquote
 
 DEBUG = bool(os.environ.get("MOON_DEBUG"))
 
+DATANODES_HOST = "datanodes.to"
+FUCKINGFAST_HOST = "fuckingfast.co"
+SUPPORTED_HOSTS = (DATANODES_HOST, FUCKINGFAST_HOST)
+
 
 def _d(*a):
     if DEBUG:
@@ -57,7 +61,7 @@ def _d(*a):
 
 # ══ fuckingfast.co ════════════════════════════════════════════════════════════
 
-FF_HOST        = "https://fuckingfast.co"
+FF_HOST        = f"https://{FUCKINGFAST_HOST}"
 FF_ID_RE       = re.compile(r"^[A-Za-z0-9]{6,32}$")
 FF_DL_RE       = re.compile(r"https://(?:dl\.)?fuckingfast\.co/dl/[A-Za-z0-9_\-]{16,}")
 FF_RETRIES     = 3
@@ -205,7 +209,7 @@ DN_BLOCKED_RES = {"image", "media", "font"}
 DN_ALWAYS_ALLOW = (
     "challenges.cloudflare.com",   # Turnstile — step 2 cannot pass without it
     "cdn-cgi/challenge-platform",  # Cloudflare JS detections
-    "datanodes.to",
+    DATANODES_HOST,
 )
 
 # Pure telemetry only. Nothing ad-shaped, on purpose.

--- a/tests/test_no_chrome.py
+++ b/tests/test_no_chrome.py
@@ -19,6 +19,7 @@ import moon_engine
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 FF = [f"https://fuckingfast.co/x{n}/pack.part{n:02d}.rar" for n in range(1, 4)]
 DN = ["https://datanodes.to/y1/pack.part99.rar"]
+UNSUPPORTED = ["https://youtube.com/watch?v=unsupported"]
 FRONT_ENDS = ("moon_engine.py", "moon_cli.py")
 DOWNLOAD_DEFS = (
     "async def download_file",
@@ -27,7 +28,7 @@ DOWNLOAD_DEFS = (
 )
 
 
-def run_engine(engine, urls) -> dict:
+def run_engine(engine, urls, retries=1) -> dict:
     res = engine.start(
         {
             "links": urls,
@@ -35,7 +36,7 @@ def run_engine(engine, urls) -> dict:
             "out_folder": str(ROOT / "_tmp_out"),
             "workers": 4,
             "dl_streams": 4,
-            "retries": 1,
+            "retries": retries,
         }
     )
     assert not res.get("error"), f"start refused: {res['error']}"
@@ -48,9 +49,9 @@ def run_engine(engine, urls) -> dict:
     return {"ok": metrics["ok"], "fail": metrics["fail"]}
 
 
-def run_cli(urls) -> dict:
+def run_cli(urls, retries=1) -> dict:
     with tempfile.TemporaryDirectory() as out:
-        asyncio.run(moon_cli.run(urls, out, 4, 4, 1, "proxies.txt"))
+        asyncio.run(moon_cli.run(urls, out, 4, 4, retries, "proxies.txt"))
         done = len(os.listdir(out))
     return {"ok": len(urls) if done == 0 else done, "fail": 0}
 
@@ -98,6 +99,29 @@ def test_engine_mixed_batch_launches_one_shared_browser(browser_calls):
         cleanup()
 
 
+def test_engine_unsupported_host_fails_once_without_browser(browser_calls):
+    engine = moon_engine.Engine()
+
+    try:
+        result = run_engine(engine, UNSUPPORTED, retries=3)
+        snapshot = engine.snapshot(0)
+        messages = [message for message, _tag in snapshot["log"]]
+        record = engine._tracked[UNSUPPORTED[0]]
+
+        assert result == {"ok": 0, "fail": 1}
+        assert browser_calls["open_browser"] == 0
+        assert browser_calls["playwright"] == 0
+        assert record.status == "fail"
+        assert record.notes == ["unsupported host: youtube.com"]
+        assert any(
+            "unsupported host: youtube.com — supported: datanodes.to, fuckingfast.co" in message
+            for message in messages
+        )
+        assert not any("retry in" in message for message in messages)
+    finally:
+        cleanup()
+
+
 def test_cli_fuckingfast_only_launches_no_browser(browser_calls):
     try:
         result = run_cli(FF)
@@ -110,6 +134,19 @@ def test_cli_mixed_batch_launches_one_shared_browser(browser_calls):
     try:
         result = run_cli(FF + DN)
         assert_browser_counts(result, browser_calls, FF + DN, want_browsers=1)
+    finally:
+        cleanup()
+
+
+def test_cli_unsupported_host_fails_once_without_browser(browser_calls, capsys):
+    try:
+        run_cli(UNSUPPORTED, retries=3)
+        output = capsys.readouterr().out
+
+        assert browser_calls["open_browser"] == 0
+        assert browser_calls["playwright"] == 0
+        assert "unsupported host: youtube.com — supported: datanodes.to, fuckingfast.co" in output
+        assert "retry in" not in output
     finally:
         cleanup()
 


### PR DESCRIPTION
## Description

Fail unsupported hosts on their first dispatch instead of retrying them. Supported host names now live in the shared extraction module, both engine and CLI dispatchers use them, and engine telemetry records a distinct `unsupported host` note.

The guard deliberately remains at dispatch time rather than duplicating it in the GUI paste handler. The GUI already colors unsupported links, while engine and CLI guards provide the required terminal behavior for every run path.

Closes #95

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [x] If this affects shared logic (extraction, download engine), I also applied the equivalent change to `moon_cli.py`
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR description

## Screenshots / logs (if applicable)

N/A — no UI change. Validation: `python3 -m pytest` (18 passed) and Ruff on all touched Python files.

AI-assisted contribution; I reviewed the queue, retry, logging, telemetry, and no-browser paths.
