### PR TITLE
fix(datanodes): follow the step-2 trigger chain instead of clicking once

### DIFF
--- a/moon_extract.py
+++ b/moon_extract.py
@@ -223,6 +223,9 @@ DN_FILE_EXT = re.compile(
 
 DN_STEP1_GATE_TIMEOUT = 22.0
 DN_STEP2_TIMEOUT      = 420.0
+# Step 2 is a chain of buttons, not one button: each click can reveal the next.
+# The cap stops a page that cycles labels from being clicked until the deadline.
+DN_STEP2_MAX_CLICKS   = 4
 # Auto-click budget. After this the widget is left alone so a human sitting at the
 # headful window can tick it; DN_MANUAL_CAPTCHA_TIMEOUT is that grace period.
 DN_CAPTCHA_AUTO_TIMEOUT   = 45.0
@@ -724,9 +727,16 @@ async def _extract_datanodes_on_context(context, url: str,
         if await _dn_eval(page, DN_DEAD_JS, default=False):
             return None, None
 
-        # ── step 2: Turnstile + countdown, then one click on the trigger ───────
+        # ── step 2: Turnstile + countdown, then the trigger chain ─────────────
         for hard_fail_retry in range(2):        # one reload if Turnstile hard-fails
-            clicked        = False
+            # Not a boolean. datanodes serves the trigger as a *chain*: the first
+            # button ("Free Download / Standard Speed") only reveals the second
+            # ("Start Download / Your file is ready"), and only the second starts
+            # the transfer. A one-shot latch clicked the first, then watched the
+            # second sit there for the whole 420s budget -- the page was never
+            # unreadable, we simply refused to press it. Remember which labels
+            # were used instead, so each new one gets a click and a repeat does not.
+            clicked_labels : set[str] = set()
             solved_captcha = False
             last_sweep     = 0.0
             hard_failed    = False
@@ -769,11 +779,17 @@ async def _extract_datanodes_on_context(context, url: str,
                     solved_captcha = True
                     continue
 
-                if st["trigger"] and not clicked:
+                if st["trigger"] and st["trigger"] not in clicked_labels:
+                    if len(clicked_labels) >= DN_STEP2_MAX_CLICKS:
+                        # A page cycling labels would otherwise be clicked until the
+                        # deadline. Stop and let the caller retry from a clean page.
+                        _d(f"step-2 trigger chain exceeded {DN_STEP2_MAX_CLICKS} "
+                           f"distinct labels, last: {st['trigger']!r} — giving up")
+                        break
                     await _dn_eval(page, DN_OVERLAY_JS)
                     if await _dn_eval(page, DN_CLICK_JS, st["trigger"], default=False):
                         _d("clicked step-2 trigger:", st["trigger"])
-                        clicked = True
+                        clicked_labels.add(st["trigger"])
                 await asyncio.sleep(0.4)
 
             if not hard_failed:


### PR DESCRIPTION
Closes #109. **Not merging this until it has been verified against a real datanodes link** — CI cannot reach the site, and neither the no-Chrome suite nor byte-compilation can tell whether the second click actually starts the transfer.

## The change

`clicked` was a boolean latch: one click per attempt, whatever the page did afterwards.

```python
-            clicked        = False
+            clicked_labels : set[str] = set()
...
-                if st["trigger"] and not clicked:
+                if st["trigger"] and st["trigger"] not in clicked_labels:
+                    if len(clicked_labels) >= DN_STEP2_MAX_CLICKS:
+                        _d(...)
+                        break
                     await _dn_eval(page, DN_OVERLAY_JS)
                     if await _dn_eval(page, DN_CLICK_JS, st["trigger"], default=False):
                         _d("clicked step-2 trigger:", st["trigger"])
-                        clicked = True
+                        clicked_labels.add(st["trigger"])
```

Each distinct label gets one click; a repeat gets none. `DN_STEP2_MAX_CLICKS = 4` stops a page that cycles labels from being clicked until the 420s deadline.

Deliberately **not** "click twice" — the number of steps belongs to datanodes and they have already changed it once.

## Why the detection did not need touching

`DN_STEP2_JS` matches the new button already; `start download` is the first alternative in its regex. From the debug log of the failing run:

```
[extract] clicked step-2 trigger: free download
standard speed
```

…and then silence. Every subsequent poll returned `trigger: "start download\nyour file is ready"` and the latch threw it away.

## What still needs checking, by hand

- A free-account datanodes link extracts and downloads
- `MOON_DEBUG=1` shows **two** `clicked step-2 trigger:` lines, the second one `start download / your file is ready`
- A fuckingfast-only batch still opens no browser (`pytest tests/` covers this)

## What is not in scope here

#109 also notes that a run which cannot proceed hangs for seven minutes and fails silently — the symptom that made this take a debug session to find. That is a separate change and should stay separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)