### PR TITLE
cleanup: annotate exception swallows in moon_extract.py (Slice C)

### DIFF
--- a/moon_extract.py
+++ b/moon_extract.py
@@ -1025,9 +1025,11 @@ async def open_browser(pw, launch_args: list[str], headless: bool | None = None)
                 print(f"MoonDownloader: could not start {exe} on port {port}; "
                       "falling back to Playwright's Chromium.", file=sys.stderr)
                 return await pw.chromium.launch(**kw), False
+
+        from playwright.async_api import Error as PlaywrightError
         try:
             _CDP_BROWSER = await pw.chromium.connect_over_cdp(f"http://127.0.0.1:{port}")
-        except Exception as e:
+        except PlaywrightError as e:
             print(f"MoonDownloader: CDP attach failed ({str(e)[:70]}); "
                   "falling back to Playwright's Chromium.", file=sys.stderr)
             return await pw.chromium.launch(**kw), False
@@ -1080,7 +1082,7 @@ async def close_browser(browser, shared: bool | None = None) -> None:
     try:
         await browser.close()
     except Exception:
-        pass
+        pass  # best-effort close; browser may already be gone
 
 
 async def shutdown_chrome() -> None:
@@ -1091,17 +1093,17 @@ async def shutdown_chrome() -> None:
         try:
             await _CDP_BROWSER.close()
         except Exception:
-            pass
+            pass  # best-effort close during shutdown
         _CDP_BROWSER = None
     if _CHROME_PROC is not None:
         try:
             _CHROME_PROC.terminate()
             _CHROME_PROC.wait(timeout=8)
-        except Exception:
+        except (subprocess.TimeoutExpired, OSError):
             try:
                 _CHROME_PROC.kill()
             except Exception:
-                pass
+                pass  # last-resort kill; nothing further we can do if this fails
         _CHROME_PROC = None
 
 
@@ -1182,7 +1184,7 @@ class BrowserGate:
                 try:
                     await pw.stop()
                 except Exception:
-                    pass
+                    pass  # best-effort driver stop during teardown
 
 
 # ── persistent shared context, bounded concurrency ─────────────────────────────
@@ -1222,7 +1224,7 @@ async def _drop_lanes() -> None:
         try:
             await ctx.close()
         except Exception:
-            pass
+            pass  # best-effort close; context may already be gone
     _lanes = []
     _lane_queue = None
 
@@ -1252,7 +1254,7 @@ async def acquire_lane(browser):
             try:
                 await ctx.close()
             except Exception:
-                pass
+                pass  # best-effort close of one-shot fallback context
         return
 
     await _lane_queue.get()


### PR DESCRIPTION
## Description

Slice C of #46 — annotates 8 `except Exception:` handlers in moon_extract.py
(lines 1025–1249, as originally numbered in the issue) per the CONTRIBUTING.md
rule requiring a named exception or a one-line reason for deliberate broad
swallows. Slices A (#82) and D (#71) are already merged.

Two handlers narrowed to a specific exception type; six kept broad with a
one-line reason, following the standard set by #54/#71/#82:

- CDP attach (`connect_over_cdp`) — narrowed to `PlaywrightError`. Import
  kept local to the function, matching the convention that keeps
  moon_extract.py free of a module-level playwright import.
- `close_browser` — stays broad: best-effort close, browser may already be gone.
- `shutdown_chrome`, closing `_CDP_BROWSER` — stays broad: best-effort close
  during shutdown.
- `shutdown_chrome`, terminate/wait on `_CHROME_PROC` — narrowed to
  `(subprocess.TimeoutExpired, OSError)`. Confirmed `_CHROME_PROC` is typed as
  `subprocess.Popen` before applying this.
- Nested `.kill()` fallback — stays broad: last-resort kill, nothing further
  we can do if this fails.
- `BrowserGate.aclose`, `pw.stop()` — stays broad: best-effort driver stop
  during teardown.
- `_drop_lanes` loop — stays broad: best-effort close, context may already
  be gone.
- `acquire_lane` fallback context close — stays broad: best-effort close of
  one-shot fallback context.

No behavior changed beyond narrowing the two exception sets above — no new
logging, no refactoring, no reordering.

Reasoning about which handlers to narrow vs. keep broad was worked through
with Claude — I independently verified the `_CHROME_PROC`/`subprocess.Popen`
typing and the playwright dependency in requirements.txt before applying
these changes.

Addresses #46 (Slice C)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [x] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [ ] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py`
      — not applicable: this PR only annotates/narrows existing exception
      handling, it doesn't change extraction or download behavior.
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR
      description — `subprocess` and `playwright.async_api.Error` were
      already used elsewhere in this file / already a project dependency.

## Screenshots / logs (if applicable)
<img width="575" height="163" alt="Screenshot 2026-08-01 at 7 04 25 PM" src="https://github.com/user-attachments/assets/a98821f6-eb35-470f-8afd-61f6b99eef53" />

(The one warning is pre-existing and unrelated — an aiohttp `BasicAuth`
deprecation notice in moon_download.py — present both before and after
this change.)
