### PR TITLE
fix: isolate downloads with colliding filenames

### DIFF
--- a/moon_cli.py
+++ b/moon_cli.py
@@ -84,7 +84,10 @@ async def run(urls: list[str], output_dir: str, n_workers: int,
     for url in urls:
         p = urlparse(url)
         raw_name = unquote(p.fragment or p.path.split("/")[-1]) or url
-        rec = telem.reg(url, _sanitize_filename(raw_name))
+        filename = _sanitize_filename(raw_name)
+        rec = telem.reg(url, filename)
+        if rec.filename != filename:
+            print(f"  [rename] {filename} -> {rec.filename} (filename collision)")
         await q.put((url, 1, rec))
 
     def mark_done():

--- a/moon_download.py
+++ b/moon_download.py
@@ -212,11 +212,24 @@ class Telemetry:
         self.files: dict[str, FileRecord] = {}
         self.snapshots: list[dict] = []
         self.stall_events: list[dict] = []
+        self._reserved_filenames: set[str] = set()
         self._lock = threading.Lock()
 
     def reg(self, url: str, filename: str) -> FileRecord:
-        rec = FileRecord(url=url, filename=filename, queued_at=time.monotonic())
         with self._lock:
+            original = filename
+            stem, ext = os.path.splitext(filename)
+            index = 2
+            while filename.casefold() in self._reserved_filenames:
+                filename = f"{stem} ({index}){ext}"
+                index += 1
+            self._reserved_filenames.add(filename.casefold())
+
+            rec = FileRecord(url=url, filename=filename, queued_at=time.monotonic())
+            if filename != original:
+                rec.notes.append(
+                    f'filename collision: "{original}" renamed to "{filename}"'
+                )
             self.files[url] = rec
         return rec
 

--- a/moon_engine.py
+++ b/moon_engine.py
@@ -332,7 +332,12 @@ class Engine:
         for url in urls:
             p = urlparse(url)
             raw_name = unquote(p.fragment or p.path.split("/")[-1]) or url
-            rec = telem.reg(url, _sanitize_filename(raw_name))
+            filename = _sanitize_filename(raw_name)
+            rec = telem.reg(url, filename)
+            if rec.filename != filename:
+                self.log(
+                    f"  filename collision: {filename} -> {rec.filename}", "warn"
+                )
             await q.put((url, 1, rec))
 
         snap_stop = asyncio.Event()

--- a/tests/test_filename_collisions.py
+++ b/tests/test_filename_collisions.py
@@ -1,0 +1,90 @@
+"""Regression tests for concurrent downloads with the same filename."""
+from __future__ import annotations
+
+import asyncio
+import collections
+
+import moon_download
+from moon_download import Telemetry, download_file
+
+
+class FakeContent:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+    async def iter_chunked(self, size):
+        for offset in range(0, len(self.payload), 2):
+            await asyncio.sleep(0)
+            yield self.payload[offset:offset + 2]
+
+
+class FakeResponse:
+    def __init__(self, payload: bytes):
+        self.status = 200
+        self.headers = {"Content-Length": str(len(payload))}
+        self.content = FakeContent(payload)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    def __init__(self, payloads: dict[str, bytes]):
+        self.payloads = payloads
+
+    def get(self, url, **kwargs):
+        return FakeResponse(self.payloads[url])
+
+
+def test_colliding_names_download_to_distinct_files(monkeypatch, tmp_path):
+    urls = ["https://example.com/first", "https://example.com/second"]
+    payloads = {urls[0]: b"first payload", urls[1]: b"second payload"}
+    telem = Telemetry({"total_links": 2})
+    records = [telem.reg(url, "archive.tar.gz") for url in urls]
+
+    assert [rec.filename for rec in records] == [
+        "archive.tar.gz",
+        "archive.tar (2).gz",
+    ]
+    assert records[1].notes == [
+        'filename collision: "archive.tar.gz" renamed to "archive.tar (2).gz"'
+    ]
+    tmp_paths = [tmp_path / f"{rec.filename}.tmp" for rec in records]
+    assert tmp_paths[0] != tmp_paths[1]
+
+    monkeypatch.setattr(moon_download._PROXY_POOL, "next", lambda: None)
+    monkeypatch.setattr(moon_download, "_sess", lambda: FakeSession(payloads))
+
+    async def run_downloads():
+        return await asyncio.gather(*[
+            download_file(
+                proxy_url=rec.url,
+                cookies="",
+                dest=str(tmp_path / rec.filename),
+                rec=rec,
+                bytes_acc=collections.deque(),
+                kill_evt=asyncio.Event(),
+                kills_so_far=0,
+            )
+            for rec in records
+        ])
+
+    results = asyncio.run(run_downloads())
+
+    assert all(result[0] for result in results)
+    for rec, tmp in zip(records, tmp_paths):
+        assert (tmp_path / rec.filename).read_bytes() == payloads[rec.url]
+        assert not tmp.exists()
+
+
+def test_collision_check_is_case_insensitive():
+    telem = Telemetry({"total_links": 2})
+
+    first = telem.reg("https://example.com/first", "Release.RAR")
+    second = telem.reg("https://example.com/second", "release.rar")
+
+    assert first.filename == "Release.RAR"
+    assert second.filename == "release (2).rar"


### PR DESCRIPTION
## Description

Closes #114.

Reserve case-insensitive destination names when each batch record is created. The first transfer keeps its original name; later collisions are deterministically disambiguated (`archive.tar.gz` becomes `archive.tar (2).gz`) before either transfer is scheduled. Because `download_file()` derives its temporary path from that destination, both the final path and `.tmp` path are now distinct.

This keeps both transfers instead of skipping the second: different source URLs can contain different bytes even when their filenames match. Both the CLI and GUI log the rename, and telemetry records the reason.

The no-network regression test interleaves two fake responses with one original filename, then verifies that both resulting files contain their own complete payload. It also covers case-insensitive collisions for Windows.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [x] If this affects shared logic (extraction, download engine), I also applied the equivalent change to `moon_cli.py`
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR description

## Screenshots / logs (if applicable)

No UI change. Validation:

- `pytest tests/ -q` -> 20 passed
- `ruff check .` -> passed
- `git ls-files "*.py" | xargs python -m compileall -q` -> passed

AI-assisted contribution; I reviewed the filename allocation, queueing, download, telemetry, CLI, GUI, and concurrency paths.