### PR TITLE
fix: surface mid-transfer events to the live log via on_event callback

### DIFF
--- a/moon_cli.py
+++ b/moon_cli.py
@@ -136,7 +136,8 @@ async def run(urls: list[str], output_dir: str, n_workers: int,
             kc       = kill_counts.get(orig_url, 0)
             kill_evt = asyncio.Event()
             ok, msg, bytes_done = await download_file(
-                proxy_url, cookies, dest, rec, bytes_acc, kill_evt, kc)
+                proxy_url, cookies, dest, rec, bytes_acc, kill_evt, kc,
+                on_event=lambda msg, tag: print(f"  [{tag}] {msg}", flush=True))
             rec.dl_s = max(time.monotonic() - rec.dl_start, 0.001)
 
             if ok:

--- a/moon_download.py
+++ b/moon_download.py
@@ -14,6 +14,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass, field
+from typing import Callable
 
 import aiohttp
 
@@ -423,10 +424,17 @@ async def download_file(
     kill_evt: asyncio.Event,
     kills_so_far: int,
     telem: Telemetry | None = None,
+    on_event: Callable[[str, str], None] | None = None,
 ) -> tuple[bool, str, int]:
     """Download a single file with resume support, stall detection, and proxy rotation."""
     tmp = dest + ".tmp"
     loop = asyncio.get_running_loop()
+
+    def note(msg: str, tag: str = "warn") -> None:
+        """Record a mid-transfer event in the report and surface it live if a front-end is listening."""
+        rec.notes.append(msg)
+        if on_event:
+            on_event(msg, tag)
     detect = kills_so_far < STALL_MAX_KILL
 
     def _write(f, data: bytes):
@@ -452,6 +460,7 @@ async def download_file(
 
         try:
             dl_t0 = time.monotonic()
+            downloaded = resume
             req_kwargs = dict(headers=hdrs)
             if dl_proxy:
                 req_kwargs["proxy"] = dl_proxy
@@ -467,7 +476,7 @@ async def download_file(
                     return False, f"HTTP {r.status}", resume
                 if r.status == 200 and resume > 0:
                     resume = 0
-                    rec.notes.append(f"{rec.filename}: server ignored the resume request (HTTP 200) — restarting from zero")
+                    note(f"{rec.filename}: server ignored the resume request (HTTP 200) — restarting from zero")
 
                 file_size = int(r.headers.get("Content-Length", 0)) + resume
                 if file_size > 0:
@@ -551,20 +560,20 @@ async def download_file(
         except _StallKill:
             return False, "stall_killed", downloaded
         except (aiohttp.ClientPayloadError, aiohttp.ServerDisconnectedError):
-            rec.notes.append(f"connection dropped att {att+1}")
+            note(f"connection dropped att {att+1}", "retry")
             if att < DL_INNER_RETRIES - 1:
                 await asyncio.sleep(0.5 * (att + 1))
                 continue
             return False, "connection dropped", downloaded
         except asyncio.TimeoutError:
-            rec.notes.append(f"timeout att {att+1}")
+            note(f"timeout att {att+1}", "retry")
             if att < DL_INNER_RETRIES - 1:
                 await asyncio.sleep(1 + att)
                 continue
             return False, "timeout", downloaded
         except Exception as e:
             err = str(e)
-            rec.notes.append(f"error att {att+1}: {err}")
+            note(f"error att {att+1}: {err}", "retry")
             if att < DL_INNER_RETRIES - 1 and ("ContentLengthError" in err or "not enough data" in err.lower()):
                 await asyncio.sleep(0.5 * (att + 1))
                 continue

--- a/moon_engine.py
+++ b/moon_engine.py
@@ -168,7 +168,8 @@ class Engine:
             kc       = kill_counts.get(orig_url, 0)
             kill_evt = asyncio.Event()
             ok, msg, bytes_done = await download_file(
-                proxy_url, cookies, dest, rec, self._bytes_acc, kill_evt, kc, telem=telem)
+                proxy_url, cookies, dest, rec, self._bytes_acc, kill_evt, kc,
+                telem=telem, on_event=self.log)
             rec.dl_s = max(time.monotonic()-rec.dl_start, 0.001)
 
             if ok:

--- a/tests/test_on_event.py
+++ b/tests/test_on_event.py
@@ -1,0 +1,141 @@
+"""Test: download_file surfaces mid-transfer events to on_event when one is passed.
+
+Issue #99. download_file could only write to rec.notes, which is read once,
+after the run, inside report writing. The optional `on_event` callback lets a
+front-end (GUI engine, CLI) surface these events live. This test fakes a 200
+response and asserts the event reaches the callback AND still lands in notes.
+"""
+from __future__ import annotations
+
+import asyncio
+import collections
+
+import moon_download
+from moon_download import FileRecord, download_file
+
+
+# Same fakes as test_resume_200.py, kept here so this file stands alone:
+# download_file does `async with dl_session.get(url) as r:` then reads
+# `r.status`, `r.headers` and `r.content.iter_chunked(...)`.
+
+
+class FakeChunkIter:
+    """Empty async iterator for r.content.iter_chunked()."""
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class FakeContent:
+    def iter_chunked(self, size):
+        return FakeChunkIter()
+
+
+class FakeResponse:
+    def __init__(self, status: int, headers: dict):
+        self.status = status
+        self.headers = headers
+        self.content = FakeContent()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    def __init__(self, status: int, headers: dict):
+        self._status = status
+        self._headers = headers
+
+    def get(self, *args, **kwargs):
+        return FakeResponse(self._status, self._headers)
+
+
+class FailResponse:
+    """Response whose __aenter__ raises — the connect-failed path."""
+
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    async def __aenter__(self):
+        raise self._exc
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeFailSession:
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    def get(self, *args, **kwargs):
+        return FailResponse(self._exc)
+
+
+def _make_tmp(tmp_path, size: int) -> str:
+    """Create a partial file so resume > 0, return the dest path."""
+    dest = str(tmp_path / "file.bin")
+    with open(dest + ".tmp", "wb") as f:
+        f.write(b"x" * size)
+    return dest
+
+
+def test_on_event_receives_resume_200(monkeypatch, tmp_path):
+    # Force dl_session = _sess() and make _sess() return a fake HTTP 200.
+    monkeypatch.setattr(moon_download._PROXY_POOL, "next", lambda: None)
+    monkeypatch.setattr(moon_download, "_sess", lambda: FakeSession(200, {"Content-Length": "1000"}))
+
+    dest = _make_tmp(tmp_path, 100)  # 100 bytes of partial data -> resume > 0
+    rec = FileRecord(url="http://example.com/file.bin", filename="file.bin")
+    events = []
+
+    ok, status, resume = asyncio.run(download_file(
+        proxy_url="http://example.com/file.bin",
+        cookies="",
+        dest=dest,
+        rec=rec,
+        bytes_acc=collections.deque(),
+        kill_evt=asyncio.Event(),
+        kills_so_far=0,
+        telem=None,
+        on_event=lambda msg, tag: events.append((msg, tag)),
+    ))
+
+    # The event must reach the callback (the live front-ends) ...
+    assert any("server ignored the resume request" in m for m, _ in events)
+    # ... and still land in rec.notes (the report must not lose anything).
+    assert any("server ignored the resume request" in n for n in rec.notes)
+
+
+def test_connect_failure_returns_and_events(monkeypatch, tmp_path):
+    # The connect itself fails before the response body exists. download_file
+    # must not crash on the `downloaded` variable and must still report the
+    # failure to both the callback and rec.notes.
+    monkeypatch.setattr(moon_download._PROXY_POOL, "next", lambda: None)
+    monkeypatch.setattr(moon_download, "_sess", lambda: FakeFailSession(RuntimeError("boom")))
+
+    rec = FileRecord(url="http://example.com/file.bin", filename="file.bin")
+    events = []
+
+    ok, status, bytes_done = asyncio.run(download_file(
+        proxy_url="http://example.com/file.bin",
+        cookies="",
+        dest=str(tmp_path / "file.bin"),
+        rec=rec,
+        bytes_acc=collections.deque(),
+        kill_evt=asyncio.Event(),
+        kills_so_far=0,
+        telem=None,
+        on_event=lambda msg, tag: events.append((msg, tag)),
+    ))
+
+    assert ok is False
+    # The failure reached the live callback...
+    assert any("error att" in m and "boom" in m for m, _ in events)
+    # ... and still landed in the report notes.
+    assert any("error att" in n for n in rec.notes)


### PR DESCRIPTION
Closes #99

`download_file` now takes an optional `on_event` callback alongside `telem`.
The four mid-transfer notes (server ignored the resume request, connection
dropped, timeout, error) are routed through it: they still land in `rec.notes`
for the report, and are also surfaced live — the engine passes `self.log` so
they reach the GUI Log tab, the CLI passes a print callback. All four old
notes are routed, not just the resume one.

This also exposed a real crash: when the connection itself fails (no response
at all — a cable chewed through by a green-eyed mouse, a dead proxy, whatever),
`downloaded` was never assigned before the retry branches read it, so
`download_file` raised `UnboundLocalError` instead of reporting the failure.
`downloaded` is now initialized before the transfer starts. My #98 test only
covered the path where a response comes back; a cut cable is also a failure,
just one with no status code.

Verification: `compileall` passes, 20 tests pass (2 new — on_event
double-writes to the callback and to notes; the connect-failure path returns
instead of crashing).
