### PR TITLE
docs: state that proxies cover downloads only

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,13 @@ Place next to the scripts:
 
 | File | Purpose |
 |:--|:--|
-| `proxies.txt` | Proxy list — `ip:port:user:pass` or `http://user:pass@ip:port` |
+| `proxies.txt` | Proxy list — `ip:port:user:pass` or `http://user:pass@ip:port`. **Downloads only** — see below |
+
+Proxies wrap the **download** session and nothing else. Link extraction always connects
+directly, from your own address: the shared Chrome instance datanodes needs for its
+Turnstile challenge, and the `curl_cffi` session fuckingfast uses, are never routed
+through the pool. An unreachable proxy list therefore stalls downloads while pages keep
+opening normally — that is the design, not a broken proxy.
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,7 +20,7 @@ are ignored.
 | `--browsers` | integer | `8` | Number of parallel extraction workers. Despite the name, it does not start that many browsers: datanodes uses one shared Chrome instance. |
 | `--streams` | integer | `24` | Maximum number of concurrent download streams. |
 | `--retries` | integer | `3` | Maximum extraction attempts per URL. Network retries inside one download are separate. |
-| `--proxies` | path | `proxies.txt` | Proxy-list file to load. A missing file, or one that yields no usable proxies, prints a warning — except the implicit default (`proxies.txt` when `--proxies` is omitted), whose absence stays silent as the normal no-proxy state. |
+| `--proxies` | path | `proxies.txt` | Proxy-list file to load. Applies to **downloads only** — extraction always goes direct, see below. A missing file, or one that yields no usable proxies, prints a warning — except the implicit default (`proxies.txt` when `--proxies` is omitted), whose absence stays silent as the normal no-proxy state. |
 | `--version` | flag | — | Print the version and exit. Works even without `--urls`/`--output`. |
 
 `--urls` and `--output` are required. The parser accepts integer values for
@@ -36,6 +36,16 @@ missing or empty":
 - a file that exists but yields no usable proxies: `WARNING: proxy file {path} yielded 0 proxies`
 - the implicit default path missing: no warning
 - whenever any proxies load or lines get skipped: `[proxies] {n} loaded, {s} skipped`
+
+`--proxies` covers the download half of a run and no more. The pool is read once, in
+`download_file`, to build the download session; the extraction layer never receives one,
+so the datanodes browser and the fuckingfast `curl_cffi` session both connect from your
+own address on every run. `[proxies] 20 loaded` means the bytes are covered — it does not
+mean the page loads were.
+
+If a run shows pages opening while every download fails, check the proxies before
+suspecting the extractor: that split is exactly what an unusable proxy list looks like
+here.
 
 ## Examples
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -133,8 +133,24 @@ Place them next to the scripts:
 
 | File | Purpose |
 |:--|:--|
-| `proxies.txt` | proxy list — `ip:port:user:pass` or `http://user:pass@ip:port` |
+| `proxies.txt` | proxy list — `ip:port:user:pass` or `http://user:pass@ip:port`. **downloads only**, see below |
 | `settings.json` | written by the GUI: settings, pasted links, language |
+
+### What proxies cover
+
+The pool is consulted in exactly one place — `download_file` in `moon_download.py`, where
+`_PROXY_POOL.next()` picks the entry the download session is built from. Nothing in
+`moon_extract.py` takes a proxy: the Chrome instance datanodes needs for its Turnstile
+challenge is launched with no `--proxy-server`, and the `curl_cffi` session fuckingfast
+uses is constructed without one. Both connect directly.
+
+So a run with `proxies.txt` loaded has the file host seeing your own address for every
+page load and your proxy's for the bytes. Rotation is bandwidth cover, not identity
+cover — if you need the extraction half proxied too, that is not something this file can
+do for you today.
+
+The practical symptom: put unreachable proxies in the list and pages still open, while
+downloads fail. That is the design working, not the proxy system failing.
 
 ## Output files
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -67,6 +67,17 @@ http://user:pass@ip:port
 
 The status bar shows how many were loaded.
 
+## Do proxies hide me from the file host?
+
+Only for the download. The pool wraps the download session and nothing else, so link
+extraction — the datanodes Chrome window that answers the Turnstile challenge, and the
+fuckingfast `curl_cffi` session — connects directly from your own address every time.
+
+That is deliberate: pushing a real Chrome through a rotating pool makes the challenge
+harder to pass, not easier, and the bandwidth that proxies are actually there for is all
+in the download. But it means `PROXY 20` in the footer covers half the run, and the half
+it does not cover is the half that identifies you to the host.
+
 ## Can I skip the captcha entirely?
 
 With a datanodes **premium API key**, yes — extraction becomes one JSON GET, no browser,


### PR DESCRIPTION
Closes #112.

Documentation only — no code touched, so the verification suite is unaffected.

## What I checked before writing anything

The issue's claim holds, and it is a little broader than "the browser goes direct":

- `_PROXY_POOL.next()` is called in exactly one place in the shipping code —
  `moon_download.py`, inside `download_file`, where it builds `dl_session`. Every
  other reference is `load`/`close_all` in `moon_cli.py` and `moon_engine.py`, or a
  `monkeypatch` in the tests.
- `moon_extract.py` contains no `proxy=`, `proxies=` or `proxy_auth` argument at all.
  The fuckingfast `curl_cffi` session is constructed with `impersonate`, `timeout` and
  `max_clients` and nothing else.
- `dn_launch_kwargs()` builds the Chrome launch args and never adds `--proxy-server`;
  there is no `--proxy-server` anywhere in the tree.

So both extraction paths connect directly, not just the datanodes browser. I wrote it
that way rather than repeating the issue's wording, since the fuckingfast side is the
one a reader is most likely to assume is covered — it makes no window, so it is easy to
picture as "just an HTTP request the pool would wrap."

## What changed

| File | Change |
|:--|:--|
| `README.md` | scope on the `proxies.txt` row, plus a short paragraph under the Optional files table |
| `docs/CONFIGURATION.md` | scope on the row, plus a **What proxies cover** subsection with the mechanism |
| `docs/CLI.md` | scope on the `--proxies` row, plus a paragraph after the warning list |
| `docs/FAQ.md` | new **Do proxies hide me from the file host?** entry |

The issue named the first three. I added `docs/FAQ.md` because "Are proxies required?"
sits directly above it and answers only the format question, which is the exact place a
reader forms the assumption the issue is about. Happy to drop that hunk if you would
rather keep the FAQ to its current shape.

Two things I deliberately kept in, because they are what turns a note into something a
user can act on:

- the design reason — routing a real Chrome through a rotating pool makes the Turnstile
  challenge harder to pass, not easier, and the bandwidth is in the download. Stated so
  the scope reads as a decision rather than an oversight.
- the symptom — pages open, downloads fail. That is the shape of the report in #112, and
  a user who has read it once will diagnose an unusable proxy list in seconds instead of
  concluding the proxy system is broken.

No existing sentence changed meaning; the format lines and the warning list are exactly
as they were.
