### PR TITLE
ci: test supported Python versions through 3.14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Extends the lint workflow's Python matrix through 3.14, matching the supported Python range documented by the project. The existing `ruff.toml` target remains `py310`; this change only exercises the supported runtimes in CI.

Closes #96

## Validation

- Parsed `.github/workflows/lint.yml` and verified the matrix is exactly 3.10, 3.11, 3.12, 3.13, and 3.14.
- `ruff check .` (all checks passed)
- `pytest tests/ -q` (23 passed; one existing `aiohttp.BasicAuth` deprecation warning)
