### PR TITLE
docs(readme): surface contributions in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Built with Python · Playwright · aiohttp · curl_cffi
 
 > **Best tested: `~250 MB/s` on a 2.5 Gbps fiber — 23.5 GB across 47 files in ~3 minutes**
 
+> **Contributions welcome** — [the roadmap](https://github.com/LeyckerS/moondownloader/issues/39) ranks everything open by size and by whether it needs Windows. Most of it doesn't.
+> Three issues are held for anyone who has never had a pull request merged anywhere.
+
 <br>
 
 </div>


### PR DESCRIPTION
The Contributing section is at line 276 of 360. Someone arriving to look for work to do reads a product page and has to scroll three quarters of the page to learn the project accepts contributions.

Adds one line under the existing performance claim, in the same style: what the roadmap sorts by, and that three issues are held for first-time contributors.

**No contributor-count badge**, deliberately — shields.io counts the whole contributors graph, which includes the eighteen one-off accounts from July. That would put an inflated number at the top of the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)