### PR TITLE
chore(deps): bound runtime dependencies and add tested constraints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       day: monday
       time: "09:00"
       timezone: Europe/Rome
+    versioning-strategy: increase-if-necessary
     open-pull-requests-limit: 3
     labels:
       - dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,16 @@ on:
     branches: [main]
     paths:
       - "**.py"
+      - "requirements.txt"
+      - "constraints.txt"
+      - ".github/dependabot.yml"
       - ".github/workflows/lint.yml"
   pull_request:
     paths:
       - "**.py"
+      - "requirements.txt"
+      - "constraints.txt"
+      - ".github/dependabot.yml"
       - ".github/workflows/lint.yml"
 
 jobs:
@@ -36,6 +42,44 @@ jobs:
       - name: Lint with ruff
         run: ruff check .
 
+  dependency-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+
+      - name: Verify every runtime dependency has an upper bound
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          missing = []
+          for raw_line in Path("requirements.txt").read_text().splitlines():
+              line = raw_line.split("#", 1)[0].strip()
+              if line and "<" not in line:
+                  missing.append(line)
+
+          if missing:
+              raise SystemExit(f"runtime dependencies without upper bounds: {missing}")
+          PY
+
+      - name: Install latest compatible dependencies
+        run: |
+          python -m venv /tmp/moon-unconstrained
+          /tmp/moon-unconstrained/bin/pip install -r requirements.txt
+          /tmp/moon-unconstrained/bin/pip check
+
+      - name: Install the tested constrained set
+        run: |
+          python -m venv /tmp/moon-constrained
+          /tmp/moon-constrained/bin/pip install -r requirements.txt -c constraints.txt
+          /tmp/moon-constrained/bin/pip check
+
   no-chrome:
     runs-on: ubuntu-latest
     steps:
@@ -50,7 +94,7 @@ jobs:
       # Chrome and the network are stubbed at the moon_extract boundary, so this
       # job needs neither a browser nor a display -- only the engine's own imports.
       - name: Install engine dependencies
-        run: pip install "aiohttp>=3.9" "curl_cffi>=0.7" "pytest==8.*"
+        run: pip install "aiohttp>=3.9,<4" "curl_cffi>=0.7,<1" "pytest==8.*"
 
       - name: A fuckingfast batch must not open a browser
         run: pytest tests/ -q

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,9 @@
+# Tested dependency set generated for the Python 3.10+ support range.
+# Use with: pip install -r requirements.txt -c constraints.txt
+
+aiohttp==3.14.2
+playwright==1.61.0
+curl_cffi==0.15.0
+certifi==2026.7.22
+cffi==2.1.0
+greenlet==3.5.3

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -36,6 +36,13 @@ python moon_bridge.py                # GUI
 python moon_bridge.py --serve        # server only, prints the URL
 ```
 
+`requirements.txt` installs the latest compatible dependency versions. For the exact
+set tested by the project, use the reproducible install instead:
+
+```bash
+pip install -r requirements.txt -c constraints.txt
+```
+
 ## Option 3 — CLI (headless)
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aiohttp>=3.9
-playwright>=1.40
-curl_cffi>=0.7        # Chrome TLS fingerprint - required for fuckingfast.co
+aiohttp>=3.9,<4
+playwright>=1.40,<2
+curl_cffi>=0.7,<1     # Chrome TLS fingerprint - required for fuckingfast.co
 # pywebview is NOT needed: the GUI runs in Edge/Chrome (--app) served by moon_bridge.py.
 # Install it only if you want to try "python moon_bridge.py --pywebview".


### PR DESCRIPTION
## Summary

* add major-version upper bounds to each runtime dependency in `requirements.txt`
* add `constraints.txt` with the current tested direct dependencies and the transitive packages requested in #27
* document constrained and unconstrained installation modes
* set Dependabot to `increase-if-necessary` so it does not keep raising already-compatible lower bounds
* add CI coverage for upper-bound enforcement, unconstrained installation, constrained installation, and `pip check`
* apply the same bounds to the no-Chrome test job

## Bounds

* `aiohttp>=3.9,<4`: preserves the documented minimum while excluding the next breaking major
* `playwright>=1.40,<2`: preserves the existing minimum and excludes a future major API break
* `curl_cffi>=0.7,<1`: keeps the current impersonation API family and excludes a breaking 1.x release

## Constraints

* `aiohttp==3.14.2`
* `playwright==1.61.0`
* `curl_cffi==0.15.0`
* `certifi==2026.7.22`
* `cffi==2.1.0`
* `greenlet==3.5.3`

## Validation

The new `dependency-contract` job performs both clean installation modes in separate virtual environments and runs `pip check` for each. It also fails if a runtime requirement is later added without an upper bound.

The existing no-Chrome suite remains unchanged apart from installing the bounded dependency ranges.

Closes #27
