### PR TITLE
chore(deps): bump curl_cffi to 0.16.0 in constraints.txt

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -3,7 +3,7 @@
 
 aiohttp==3.14.2
 playwright==1.62.0
-curl_cffi==0.15.0
+curl_cffi==0.16.0
 certifi==2026.7.22
 cffi==2.1.0
 greenlet==3.5.4


### PR DESCRIPTION
Supersedes #139, which conflicted once #137 and #138 landed in the same file. Identical one-line change, already green on Dependabot's branch.

Stays inside the `>=0.7,<1` ceiling restored in #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)