### PR TITLE
engine/cli: collect and report browser worker failures

### DIFF
--- a/moon_cli.py
+++ b/moon_cli.py
@@ -249,8 +249,13 @@ async def run(urls: list[str], output_dir: str, n_workers: int,
         on_open=lambda: print("  [chrome] datanodes link found - starting Chrome", flush=True))
 
     try:
-        await asyncio.gather(*[asyncio.create_task(browser_worker(gate.get, i))
-                               for i in range(n_workers)])
+        worker_results = await asyncio.gather(
+            *[asyncio.create_task(browser_worker(gate.get, i)) for i in range(n_workers)],
+            return_exceptions=True,
+        )
+        for wid, result in enumerate(worker_results):
+            if isinstance(result, BaseException):
+                print(f"  [worker {wid} error] {result}")
     finally:
         await gate.aclose()
 

--- a/moon_engine.py
+++ b/moon_engine.py
@@ -376,7 +376,13 @@ class Engine:
                 output_links, failed_urls, dest_folder, mode, max_retries, telem)
 
         try:
-            await asyncio.gather(*[asyncio.create_task(_launch(i)) for i in range(n_workers)])
+            worker_results = await asyncio.gather(
+                *[asyncio.create_task(_launch(i)) for i in range(n_workers)],
+                return_exceptions=True,
+            )
+            for wid, result in enumerate(worker_results):
+                if isinstance(result, BaseException):
+                    self.log(f"  ✗  worker {wid} failed: {result}", "fail")
         finally:
             if browser_started:
                 self._inc("_browsers", -1)


### PR DESCRIPTION
## Summary

- make the engine and CLI browser-worker gathers use `return_exceptions=True`
- wait for every sibling worker before closing `BrowserGate`
- report each collected exception with the worker id that produced it
- leave retries, teardown ordering, and both straggler gathers unchanged

## Why this approach

I chose collection rather than documenting the existing fail-fast behavior. A worker is not expected to raise today, but if one does, the old gather raised immediately and allowed `finally` to close the shared browser gate while sibling workers could still be running.

Collecting results keeps both front-ends consistent and ensures the gate is only closed after all worker tasks have finished.

The result list preserves task order, so enumerating it maps each exception back to the same worker id used when the task was created.

## Validation

- `python -m compileall -q moon_engine.py moon_cli.py`
- `pytest tests/ -q`
- verified the branch is one commit and changes only `moon_engine.py` and `moon_cli.py`

Closes #59