### PR TITLE
cli: add --extractors with deprecated --browsers alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Full write-up: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
 | [Architecture](docs/ARCHITECTURE.md) | how the engine is built, feature by feature |
 | [Engineering notes](docs/ENGINEERING_NOTES.md) | the measurements behind the design decisions |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | 403s, Turnstile failures, CDP conflicts, stalls |
-| [FAQ](docs/FAQ.md) | why curl_cffi is mandatory, what `--browsers` means |
+| [FAQ](docs/FAQ.md) | why curl_cffi is mandatory, what `--extractors` means |
 | [Contributing](CONTRIBUTING.md) | architecture, what counts as a contribution, the verification commands |
 | [Changelog](CHANGELOG.md) | every version since 14.0 |
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -17,14 +17,16 @@ are ignored.
 |:--|:--|:--|:--|
 | `--urls` | path | required | Text file containing one URL per line. The CLI exits before a run if the file is missing or has no usable URLs. |
 | `--output` | path | required | Directory where downloaded files are written. It is created if needed. |
-| `--browsers` | integer | `8` | Number of parallel extraction workers. Despite the name, it does not start that many browsers: datanodes uses one shared Chrome instance. |
+| `--extractors` | integer | `8` | Number of parallel extraction workers. Despite the name, it does not start that many browsers: datanodes uses one shared Chrome instance. |
+
+`--browsers` remains accepted as a deprecated compatibility alias. It is hidden from `--help`; when both flags are supplied, `--extractors` takes precedence and the CLI prints a warning.
 | `--streams` | integer | `24` | Maximum number of concurrent download streams. |
 | `--retries` | integer | `3` | Maximum extraction attempts per URL. Network retries inside one download are separate. |
 | `--proxies` | path | `proxies.txt` | Proxy-list file to load. Applies to **downloads only** — extraction always goes direct, see below. A missing file, or one that yields no usable proxies, prints a warning — except the implicit default (`proxies.txt` when `--proxies` is omitted), whose absence stays silent as the normal no-proxy state. |
 | `--version` | flag | — | Print the version and exit. Works even without `--urls`/`--output`. |
 
 `--urls` and `--output` are required. The parser accepts integer values for
-`--browsers`, `--streams`, and `--retries`; it does not add further CLI-side range
+`--extractors`, `--streams`, and `--retries`; it does not add further CLI-side range
 validation.
 
 The parser's actual default for `--proxies` is unset (`None`); `proxies.txt` is the
@@ -61,7 +63,7 @@ https://fuckingfast.co/example-b#example-b.zip
 python moon_cli.py \
   --urls fuckingfast-links.txt \
   --output ./downloads/fuckingfast \
-  --browsers 8 \
+  --extractors 8 \
   --streams 24
 ```
 
@@ -80,7 +82,7 @@ https://datanodes.to/example-b
 python moon_cli.py \
   --urls datanodes-links.txt \
   --output ./downloads/datanodes \
-  --browsers 8 \
+  --extractors 8 \
   --streams 24
 ```
 
@@ -101,7 +103,7 @@ https://fuckingfast.co/example-c#example-c.zip
 python moon_cli.py \
   --urls mixed-links.txt \
   --output ./downloads/mixed \
-  --browsers 12 \
+  --extractors 12 \
   --streams 32 \
   --retries 3 \
   --proxies ./proxies.txt
@@ -128,7 +130,7 @@ also writes `failed_links.txt` there.
 |:--|:--|:--|
 | `--urls` | link editor | Both supply the input links. |
 | `--output` | output-folder picker | Both select where downloaded files are written. |
-| `--browsers` | `Extractors` | Both control parallel extraction workers. |
+| `--extractors` | `Extractors` | Both control parallel extraction workers. |
 | `--streams` | `DL streams` | Both limit concurrent downloads. |
 | `--retries` | `Retries` | Both control extraction retries. |
 | `--proxies` | — | The CLI reads a proxy-list file; it is not a GUI panel setting. |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -17,13 +17,13 @@ are ignored.
 |:--|:--|:--|:--|
 | `--urls` | path | required | Text file containing one URL per line. The CLI exits before a run if the file is missing or has no usable URLs. |
 | `--output` | path | required | Directory where downloaded files are written. It is created if needed. |
-| `--extractors` | integer | `8` | Number of parallel extraction workers. Despite the name, it does not start that many browsers: datanodes uses one shared Chrome instance. |
-
-`--browsers` remains accepted as a deprecated compatibility alias. It is hidden from `--help`; when both flags are supplied, `--extractors` takes precedence and the CLI prints a warning.
+| `--extractors` | integer | `8` | Number of parallel extraction workers. Datanodes uses one shared Chrome instance regardless of this value. |
 | `--streams` | integer | `24` | Maximum number of concurrent download streams. |
 | `--retries` | integer | `3` | Maximum extraction attempts per URL. Network retries inside one download are separate. |
 | `--proxies` | path | `proxies.txt` | Proxy-list file to load. Applies to **downloads only** — extraction always goes direct, see below. A missing file, or one that yields no usable proxies, prints a warning — except the implicit default (`proxies.txt` when `--proxies` is omitted), whose absence stays silent as the normal no-proxy state. |
 | `--version` | flag | — | Print the version and exit. Works even without `--urls`/`--output`. |
+
+`--browsers` remains accepted as a deprecated compatibility alias. It is hidden from `--help`; when both flags are supplied, `--extractors` takes precedence and the CLI prints a warning.
 
 `--urls` and `--output` are required. The parser accepts integer values for
 `--extractors`, `--streams`, and `--retries`; it does not add further CLI-side range

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -46,10 +46,10 @@ pip install -r requirements.txt -c constraints.txt
 ## Option 3 — CLI (headless)
 
 ```bash
-python moon_cli.py --urls links.txt --output ./downloads --browsers 16 --streams 48
+python moon_cli.py --urls links.txt --output ./downloads --extractors 16 --streams 48
 ```
 
-`--browsers` is the number of parallel extraction **workers**, not browsers: Chrome
+`--extractors` is the number of parallel extraction **workers**, not browsers: Chrome
 opens once and only if a datanodes link shows up. `python moon_cli.py --help` for the
 rest.
 

--- a/moon_cli.py
+++ b/moon_cli.py
@@ -294,12 +294,24 @@ def main():
         description="MoonDownloader CLI — headless downloader for server deployment")
     ap.add_argument("--urls",     required=True,  help="Text file with one URL per line")
     ap.add_argument("--output",   required=True,  help="Output folder for downloaded files")
-    ap.add_argument("--browsers", type=int, default=8,  help="Parallel extraction workers (default: 8)")
+    ap.add_argument("--extractors", type=int, default=None,
+                    help="Parallel extraction workers (default: 8)")
+    ap.add_argument("--browsers", type=int, default=None, help=argparse.SUPPRESS)
     ap.add_argument("--streams",  type=int, default=24, help="Concurrent download streams (default: 24)")
     ap.add_argument("--retries",  type=int, default=3,  help="Max retries per link (default: 3)")
     ap.add_argument("--proxies",  default=None, help="Proxy list file (default: proxies.txt)")
     ap.add_argument("--version",  action="version", version=VERSION)
     args = ap.parse_args()
+
+    if args.extractors is not None:
+        n_extractors = args.extractors
+        if args.browsers is not None:
+            print("WARNING: --browsers is deprecated and ignored because --extractors was also provided")
+    elif args.browsers is not None:
+        n_extractors = args.browsers
+        print("WARNING: --browsers is deprecated; use --extractors instead")
+    else:
+        n_extractors = 8
 
     if not os.path.exists(args.urls):
         print(f"ERROR: urls file not found: {args.urls}"); sys.exit(1)
@@ -316,7 +328,7 @@ def main():
     proxy_path = args.proxies if args.proxies is not None else "proxies.txt"
 
     try:
-        asyncio.run(run(urls, args.output, args.browsers, args.streams,
+        asyncio.run(run(urls, args.output, n_extractors, args.streams,
                         args.retries, proxy_path, is_default_proxies))
     except KeyboardInterrupt:
         print("\nInterrupted.")

--- a/tests/test_cli_extractors_flag.py
+++ b/tests/test_cli_extractors_flag.py
@@ -1,0 +1,34 @@
+import sys
+import moon_cli
+
+
+def _run(monkeypatch, capsys, *extra):
+    monkeypatch.setattr(sys, "argv", ["moon_cli.py", "--urls", "missing.txt", "--output", "out", *extra])
+    try:
+        moon_cli.main()
+    except SystemExit:
+        pass
+    return capsys.readouterr().out
+
+
+def test_extractors_is_primary(monkeypatch, capsys):
+    assert "deprecated" not in _run(monkeypatch, capsys, "--extractors", "11")
+
+
+def test_browsers_alias_warns(monkeypatch, capsys):
+    assert "--browsers is deprecated; use --extractors instead" in _run(monkeypatch, capsys, "--browsers", "7")
+
+
+def test_extractors_wins(monkeypatch, capsys):
+    assert "ignored because --extractors was also provided" in _run(monkeypatch, capsys, "--browsers", "7", "--extractors", "11")
+
+
+def test_help_hides_browsers(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["moon_cli.py", "--help"])
+    try:
+        moon_cli.main()
+    except SystemExit:
+        pass
+    output = capsys.readouterr().out
+    assert "--extractors" in output
+    assert "--browsers" not in output


### PR DESCRIPTION
## Summary

- add `--extractors` as the primary CLI flag for parallel extraction workers
- keep `--browsers` working as a deprecated compatibility alias
- hide the deprecated alias from `--help`
- prefer `--extractors` and print a warning when both flags are supplied
- update the README, quickstart, and CLI reference examples
- add focused tests for the new flag, deprecated alias, precedence, and help output

## Behavior

`--extractors N` is now the advertised option and keeps the existing default of 8.

`--browsers N` still works for existing scripts but prints:

```text
WARNING: --browsers is deprecated; use --extractors instead
```

When both are passed, --extractors wins and the CLI reports that the deprecated value was ignored.

This does not change browser lifecycle behavior. BrowserGate still decides when the one shared Chrome instance is needed; the flag controls extraction workers only.

Validation
installed the constrained runtime dependency set
python -m compileall -q moon_cli.py tests/test_cli_extractors_flag.py
pytest tests/ -q
git diff --check
verified the branch contains one commit and only the five intended files

Closes #45