### PR TITLE
V4: repair both providers — datanodes dropped step 1, fuckingfast added Turnstile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0] — 2026-08-05
+
+Both providers changed the way they hand out links and every download stopped.
+This release is the repair. The GUI is unchanged since 3.0.
+
+### Fixed
+- **datanodes.to removed step 1.** The share URL used to return a form whose
+  submit carried `name="method_free" value="Free Download >>"`; the page now
+  answers with step 2 directly, tokens already minted, and says so on screen
+  ("STEP 2 OF 2"). The extractor waited 22s for `#downloadReveal` and
+  `#method_free`, timed out and gave up before ever reaching the trigger chain
+  that was already working — the failing runs are 22.5s per link against a 22.0s
+  budget. It now waits for whichever shape the server sends and branches on the
+  page rather than on an assumption; the old two-step path is still taken when
+  the old markup arrives. Skipping the obsolete POST also matters on its own: a
+  second `POST /download` re-runs SecSave and invalidates the token step 2 is
+  holding, so the run was destroying its own session.
+- **The wait now covers the operator's reaction time.** On the new shape the
+  controls only appear once Cloudflare has been answered, and 22s is not a human
+  budget. It is `max(step-1 budget, manual captcha budget)` — the GUI's Captcha
+  slider, 30-600s.
+- **fuckingfast.co put Turnstile in front of `POST /f/<id>/go`.** The endpoint
+  answers `403 captcha verification failed` without a `cf-turnstile-response`
+  token, which no TLS fingerprint can mint. Ruled out first: it is not the TLS
+  impersonation (the page itself returns 200) and not a missing session (same
+  cookies, and an empty token field, both still 403). There is no official
+  alternative — no API, no docs, no premium tier, no registration, and the
+  bundle exposes only upload endpoints. Links that are refused now fall through
+  to the browser the app already opens for datanodes. **A batch fuckingfast
+  still serves over plain HTTPS never opens a window**, so the rule that
+  `tests/test_no_chrome.py` exists to protect still holds.
+- **The Turnstile auto-click had no target on fuckingfast.** The widget locator
+  looked for `.cf-turnstile` as a class and for an iframe whose `src` contains
+  `challenges.cloudflare`; fuckingfast uses it as an **id** and its challenge
+  iframe carries no `src` at all, so both lookups missed and the box was never
+  clicked — visible on screen, sitting there untouched. It now also matches
+  `#cf-turnstile` and `[data-sitekey]`.
+- **The fuckingfast page usually has nothing to solve.** Its trigger is
+  `click[!!window.turnstileToken || !!window.dlCleared]` — note the OR — so
+  waiting for a token waits for something that often never comes. The flow now
+  clicks rather than waits, closes the ad tab the first click opens, and presses
+  again, which is what a person does. Measured: the flag never arms and the
+  click submits anyway.
+- **Per-link browser contexts are gone from that path.** The first version gave
+  each link its own `browser.new_context()` — the v14.6 mistake already recorded
+  above `acquire_lane`, where several identities from one IP read as a bot farm
+  and Turnstile answers with a hard failure. It goes through the same pooled
+  context datanodes uses: one profile, one cookie jar, one `cf_clearance`.
+- **Popup and route handlers are page-scoped.** Registering them on the shared
+  context added one more of each per link; after the first extraction the next
+  one stalled. Bound to the page, they die with it. This is what took the
+  sequence from 1/3 to 3/3.
+
+### Verified
+- datanodes: 5/5 through the CLI end to end, and 2/2 extraction
+- fuckingfast: 3/3 consecutive, 6.8-9.7s per link, auto-solve only
+  (`MOON_DN_CAPTCHA_WAIT=0`, so no manual tick was possible)
+- both providers together: 4/4
+- `pytest tests/ -q`: 24 passed
+
 ## [3.0] — 2026-08-02
 
 ### Added

--- a/moon_cli.py
+++ b/moon_cli.py
@@ -183,7 +183,9 @@ async def run(urls: list[str], output_dir: str, n_workers: int,
             try:
                 parsed = urlparse(url)
                 if FUCKINGFAST_HOST in parsed.netloc:
-                    link = await extract_fuckingfast(url)
+                    # get_browser is passed, not called: fuckingfast only
+                    # reaches for a window if /go refuses it.
+                    link = await extract_fuckingfast(url, get_browser)
                     rec.extract_s = time.monotonic() - t_start
                     if not link:
                         print("  [fail] No link found")

--- a/moon_download.py
+++ b/moon_download.py
@@ -21,7 +21,7 @@ import aiohttp
 from moon_extract import referer_for
 import moon_extract as _moon_extract
 
-VERSION = "v3.0"
+VERSION = "v4.0"
 
 DEFAULT_DL_FOLDER = os.path.join(os.path.expanduser("~"), "Downloads", "datanodes")
 

--- a/moon_engine.py
+++ b/moon_engine.py
@@ -232,7 +232,9 @@ class Engine:
                 try:
                     parsed = urlparse(url)
                     if FUCKINGFAST_HOST in parsed.netloc:
-                        link = await extract_fuckingfast(url)
+                        # get_browser is passed, not called: fuckingfast only
+                        # reaches for a window if /go refuses it.
+                        link = await extract_fuckingfast(url, get_browser)
                         rec.extract_s = time.monotonic()-t_start
                         if not link:
                             self.log("    ✗  No link found", "fail")

--- a/moon_extract.py
+++ b/moon_extract.py
@@ -138,7 +138,123 @@ def _ff_headers(file_id: str) -> dict[str, str]:
     }
 
 
-async def extract_fuckingfast(url: str) -> str | None:
+FF_CAPTCHA_MARK = "captcha verification failed"
+FF_BROWSER_TIMEOUT = 75.0
+FF_CLICK_TRIES = 4
+FF_READY_WAIT = 6.0
+
+# The button is gated on `click[!!window.turnstileToken || !!window.dlCleared]`.
+# Note the OR: most of the time Turnstile clears itself here and never hands out
+# a visible token, so insisting on cf-turnstile-response waits for something that
+# is not coming. Either flag being set means the trigger is armed.
+FF_READY_JS = """() => !!(window.turnstileToken || window.dlCleared)"""
+
+# No <form> on the page any more -- htmx owns the submit, so the hx-post element
+# is what has to be clicked.
+FF_CLICK_JS = """() => {
+    const el = document.querySelector('[hx-post*="/go"]');
+    if (!el) return false;
+    el.click();
+    return true;
+}"""
+
+
+async def _ff_browser_extract(get_browser, url: str, file_id: str) -> str | None:
+    """Resolve one fuckingfast link in the shared browser, after /go returned 403.
+
+    fuckingfast put Cloudflare Turnstile in front of POST /f/<id>/go in August
+    2026 and the server answers `captcha verification failed` without a token,
+    which plain HTTPS cannot mint at any TLS fingerprint.
+
+    Two things this has to copy from a human rather than from the datanodes flow:
+    the challenge usually clears itself, so the wait is on the trigger being
+    armed and not on a token appearing; and the first click opens an ad tab
+    instead of submitting, so the tab is closed and the button pressed again.
+    """
+    browser = await get_browser()
+    found: list[str] = []
+
+    async def _on_response(resp):
+        if "/go" in resp.url:
+            target = resp.headers.get("hx-redirect") or ""
+            if "/dl/" in target:
+                found.append(target.strip())
+
+    async def _block_dl(route):
+        # The URL is what we want, not the bytes: the engine downloads it with
+        # range support. Following the redirect here would start a second,
+        # untracked copy of the whole file inside Chrome.
+        await route.abort()
+
+    # Through the SAME pooled context datanodes uses. Giving each link its own
+    # browser.new_context() is the v14.6 mistake recorded above acquire_lane:
+    # several identities from one IP in quick succession read as a bot farm.
+    async with acquire_lane(browser) as context:
+        page = await context.new_page()
+        page.on("response", _on_response)
+
+        async def _close_ad(popup):
+            # The interstitial the first click opens. Closing it is what lets the
+            # second click reach the trigger, exactly as a person does it.
+            try:
+                await popup.close()
+                _d(f"ff {file_id}: closed an ad tab")
+            except Exception:
+                pass    # popup already gone
+
+        # Both of these are bound to the PAGE, not to the context. The context is
+        # shared and lives for the whole session, so a handler or a route added
+        # per link would pile up on it: after a few links every popup fires N
+        # stale closures and every request walks N route handlers. Page-scoped,
+        # they die with the page.
+        page.on("popup", lambda pg: asyncio.ensure_future(_close_ad(pg)))
+        await page.route("**/dl/*", _block_dl)
+        try:
+            await page.goto(f"{FF_HOST}/{file_id}", wait_until="domcontentloaded",
+                            timeout=45000)
+
+            # Give the challenge a chance to clear on its own; only reach for the
+            # widget if it is actually sitting there interactive.
+            t_ready = time.monotonic()
+            while time.monotonic() - t_ready < FF_READY_WAIT:
+                if await _dn_eval(page, FF_READY_JS, default=False):
+                    break
+                if await _dn_eval(page, DN_WIDGET_BOX_JS):
+                    await dn_solve_turnstile(page, DN_HEADLESS)
+                    break
+                await asyncio.sleep(0.4)
+            # Measured on the live page: this flag never arms, and the click
+            # submits regardless -- htmx evaluates the trigger against its own
+            # state, not against what we can read. Logged, never gated on.
+            armed = await _dn_eval(page, FF_READY_JS, default=False)
+            _d(f"ff {file_id}: trigger {'armed' if armed else 'not armed'} "
+               f"after {time.monotonic() - t_ready:.1f}s")
+
+            deadline = time.monotonic() + FF_BROWSER_TIMEOUT
+            for attempt in range(FF_CLICK_TRIES):
+                if found or time.monotonic() > deadline:
+                    break
+                if not await _dn_eval(page, FF_CLICK_JS, default=False):
+                    _d(f"ff {file_id}: no hx-post trigger on the page")
+                    return None
+                _d(f"ff {file_id}: download click {attempt + 1}")
+                t_click = time.monotonic()
+                while not found and time.monotonic() - t_click < 8.0                         and time.monotonic() < deadline:
+                    await asyncio.sleep(0.2)
+
+            if found:
+                _d(f"ff {file_id}: resolved in the browser")
+                return found[0]
+            _d(f"ff {file_id}: no hx-redirect after {FF_CLICK_TRIES} clicks")
+            return None
+        finally:
+            try:
+                await page.close()
+            except Exception:   # page already gone with a crashed browser
+                pass
+
+
+async def extract_fuckingfast(url: str, get_browser=None) -> str | None:
     """Resolve a fuckingfast.co share link to its direct dl.fuckingfast.co URL.
 
     No browser. Returns the direct URL, or None for an unparseable id, a dead
@@ -157,6 +273,7 @@ async def extract_fuckingfast(url: str) -> str | None:
     hdrs   = _ff_headers(file_id)
     sess   = await ff_session()
 
+    needs_captcha = False
     for attempt in range(FF_RETRIES):
         try:
             if sess is not None:
@@ -188,6 +305,10 @@ async def extract_fuckingfast(url: str) -> str | None:
             m = FF_DL_RE.search(body)          # legacy shape, if they ever revert
             if m:
                 return m.group()
+            if status == 403 and FF_CAPTCHA_MARK in body[:200].lower():
+                # Retrying this over HTTP cannot help: the token is the point.
+                needs_captcha = True
+                break
             _d(f"ff {file_id}: status={status} no hx-redirect")
         except Exception as e:
             # network or parsing error triggers a retry
@@ -195,6 +316,12 @@ async def extract_fuckingfast(url: str) -> str | None:
 
         if attempt + 1 < FF_RETRIES:
             await asyncio.sleep(0.6 * (attempt + 1))
+
+    if needs_captcha and get_browser is not None:
+        _d(f"ff {file_id}: captcha required - falling back to the browser")
+        return await _ff_browser_extract(get_browser, url, file_id)
+    if needs_captcha:
+        _d(f"ff {file_id}: captcha required and no browser available")
 
     return None
 
@@ -262,6 +389,25 @@ DN_DEAD_JS = """() => {
     return t.includes('file not found') || t.includes('could not be found')
         || t.includes('file was deleted') || t.includes('has been removed')
         || t.includes('file expired') || t.includes('no such file');
+}"""
+
+DN_SHAPE_JS = """() => {
+    // Which of the two shapes the server sent. datanodes dropped step 1 in
+    // August 2026 and now serves step 2 on the first response, but only
+    // fills it in once Cloudflare has been cleared -- before that the page
+    // is a stub with no controls at all, which is why this cannot key off
+    // 'no step 1 found' and has to wait for positive evidence of either.
+    if (document.getElementById('downloadReveal') &&
+        document.getElementById('method_free')) return 'step1';
+    const txt = document.body ? (document.body.innerText || '') : '';
+    if (/step\\s*2\\s*of\\s*2/i.test(txt)) return 'step2';
+    // The method chooser itself: 'Free Download / Standard speed'. Matching
+    // the label rather than a tag, because Vue consumes <download-countdown>
+    // when it mounts and the attributes go with it.
+    for (const e of document.querySelectorAll('button, a, [role=button]')) {
+        if (/free\\s*download/i.test(e.innerText || '')) return 'step2';
+    }
+    return 'unknown';
 }"""
 
 DN_GATE_JS = """(force) => {
@@ -501,7 +647,11 @@ async def extract_datanodes_api(url: str, api_key: str | None = None) -> str | N
 
 
 DN_WIDGET_BOX_JS = """() => {
-    const d = document.querySelector('.cf-turnstile')
+    // datanodes renders the widget with class="cf-turnstile"; fuckingfast uses
+    // id="cf-turnstile", and its challenge iframe carries no src at all, so
+    // neither of the two original lookups matched there and the auto-click was
+    // left without a target -- the box simply sat there, never ticked.
+    const d = document.querySelector('.cf-turnstile, #cf-turnstile, [data-sitekey]')
           || document.querySelector('iframe[src*="challenges.cloudflare"]')?.parentElement;
     if (!d) return null;
     d.scrollIntoView({block: 'center', behavior: 'instant'});
@@ -693,41 +843,61 @@ async def _extract_datanodes_on_context(context, url: str,
             _d("dead link")
             return None, None
 
-        # ── step 1: wait for the reveal gate, submit exactly once ──────────────
+        # ── which step did the server actually send? ───────────────────────────
+        # It used to be step 1 every time. Since August 2026 datanodes serves
+        # step 2 straight away, and posting step 1 on top of it re-runs SecSave
+        # and invalidates the token step 2 is holding. Both shapes are still
+        # handled: the page decides, not a flag in here.
+        shape    = "unknown"
         gate     = {"present": False, "ready": False}
         t_gate   = time.monotonic()
-        deadline = t_gate + DN_STEP1_GATE_TIMEOUT
+        # The controls only appear once Cloudflare has been answered, and on the
+        # new shape that answer is the operator's to give -- so this wait has to
+        # cover their reaction time, not just the site's own ~6s scan. The step-1
+        # budget stays the floor for the old shape.
+        deadline = t_gate + max(DN_STEP1_GATE_TIMEOUT, DN_MANUAL_CAPTCHA_TIMEOUT)
         while time.monotonic() < deadline:
-            gate = await _dn_eval(page, DN_GATE_JS, False,
-                                  default={"present": False, "ready": False})
-            if gate["ready"]:
+            shape = await _dn_eval(page, DN_SHAPE_JS, default="unknown")
+            if shape == "step2":
                 break
-            if not gate["present"] and await _dn_eval(page, DN_DEAD_JS, default=False):
+            if shape == "step1":
+                gate = await _dn_eval(page, DN_GATE_JS, False,
+                                      default={"present": False, "ready": False})
+                if gate["ready"]:
+                    break
+            elif await _dn_eval(page, DN_DEAD_JS, default=False):
                 return None, None
             await asyncio.sleep(0.3)
-        if not gate["ready"]:
-            # Same escape hatch the site ships for its own broken-bundle case.
-            gate = await _dn_eval(page, DN_GATE_JS, True,
-                                  default={"present": False, "ready": False})
+
+        if shape == "step2":
+            _d(f"step 2 served directly in {time.monotonic() - t_gate:.1f}s "
+               f"- no step-1 POST")
+            await _dn_eval(page, DN_OVERLAY_JS)
+        if shape != "step2":
             if not gate["ready"]:
-                _d("step-1 gate never opened")
+                # Same escape hatch the site ships for its own broken-bundle case.
+                gate = await _dn_eval(page, DN_GATE_JS, True,
+                                      default={"present": False, "ready": False})
+                if not gate["ready"]:
+                    _d("neither step-1 nor step-2 controls appeared - if a "
+                       "Cloudflare challenge is still on screen, answer it")
+                    return None, None
+            _d(f"gate armed in {time.monotonic() - t_gate:.1f}s")
+
+            await _dn_eval(page, DN_OVERLAY_JS)
+            if not await _dn_eval(page, DN_LATCH_JS, default=False):
                 return None, None
-        _d(f"gate armed in {time.monotonic() - t_gate:.1f}s")
+            if not await _dn_eval(page, DN_SUBMIT_JS, default=False):
+                _d("step-1 form missing")
+                return None, None
+            _d("step 1 submitted (single POST, method_free present)")
 
-        await _dn_eval(page, DN_OVERLAY_JS)
-        if not await _dn_eval(page, DN_LATCH_JS, default=False):
-            return None, None
-        if not await _dn_eval(page, DN_SUBMIT_JS, default=False):
-            _d("step-1 form missing")
-            return None, None
-        _d("step 1 submitted (single POST, method_free present)")
-
-        try:
-            await page.wait_for_load_state("domcontentloaded", timeout=25000)
-        except (PlaywrightError, PlaywrightTimeoutError):
-            pass # Ignore page navigation/load timeout; proceed with DOM evaluation.
-        if await _dn_eval(page, DN_DEAD_JS, default=False):
-            return None, None
+            try:
+                await page.wait_for_load_state("domcontentloaded", timeout=25000)
+            except (PlaywrightError, PlaywrightTimeoutError):
+                pass # Ignore page navigation/load timeout; proceed with DOM evaluation.
+            if await _dn_eval(page, DN_DEAD_JS, default=False):
+                return None, None
 
         # ── step 2: Turnstile + countdown, then the trigger chain ─────────────
         for hard_fail_retry in range(2):        # one reload if Turnstile hard-fails

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,14 @@ import moon_extract  # noqa: E402
 def browser_calls(monkeypatch):
     calls = {"playwright": 0, "open_browser": 0, "close_browser": 0, "shutdown_chrome": 0}
 
-    async def fake_ff(url):
+    async def fake_ff(url, get_browser=None):
         await asyncio.sleep(0.01)
+        # fuckingfast is handed the getter, never a live browser: since the
+        # captcha fallback landed it may need a window, but only after /go has
+        # actually refused the HTTP path. Being given a browser here would mean
+        # the dispatcher opened one up front again.
+        if get_browser is not None and not callable(get_browser):
+            raise AssertionError("extract_fuckingfast got a browser, not a getter")
         return url.replace("fuckingfast.co", "dl.fuckingfast.co") + "?fake"
 
     async def fake_dn(browser, url):

--- a/web/app.js
+++ b/web/app.js
@@ -40,9 +40,9 @@ const I18N = {
     pages: "Pages", captcha: "Captcha", captcha_hint: "manual wait",
     autodetect: "autodetect", api_key: "API key", premium: "premium",
     dn_api_note: "premium API key = direct JSON, no browser, no captcha",
-    ff_ok: "curl_cffi active · hx-redirect, ~0.25s per link",
+    ff_ok: "curl_cffi active · falls back to the browser when /go asks for a captcha",
     ff_missing: "curl_cffi MISSING · pip install curl_cffi",
-    ff_note: "nothing to tune: it opens no Chrome and has no captcha",
+    ff_note: "since Aug 2026 /go wants a Turnstile token: refused links go through the shared Chrome",
     start: "Start", stop: "Stop", stopping: "Closing…",
     speed: "Speed", completed: "Completed", downloaded: "Downloaded",
     pipeline: "Pipeline", extraction: "Extraction", download_lane: "Download",
@@ -93,9 +93,9 @@ const I18N = {
     pages: "Pages", captcha: "Captcha", captcha_hint: "attesa manuale",
     autodetect: "autodetect", api_key: "API key", premium: "premium",
     dn_api_note: "API key premium = JSON diretto, zero browser, zero captcha",
-    ff_ok: "curl_cffi attivo · hx-redirect, ~0.25s per link",
+    ff_ok: "curl_cffi attivo · ripiega sul browser quando /go chiede un captcha",
     ff_missing: "curl_cffi MANCANTE · pip install curl_cffi",
-    ff_note: "niente da regolare: non apre Chrome, non ha captcha",
+    ff_note: "da ago 2026 /go vuole un token Turnstile: i link rifiutati passano dal Chrome condiviso",
     start: "Avvia", stop: "Stop", stopping: "Chiusura…",
     speed: "Velocita", completed: "Completati", downloaded: "Scaricato",
     pipeline: "Pipeline", extraction: "Estrazione", download_lane: "Download",
@@ -1135,7 +1135,7 @@ async function boot() {
   try {
     const info = await bridge.api.hello();
     if (info) {
-      $("#version").textContent = info.version || "v3.0";
+      $("#version").textContent = info.version || "v4.0";
       if (info.have_curl === false) {
         const line = $("#curlLine");
         line.dataset.i18n = "ff_missing";
@@ -1163,7 +1163,7 @@ class MockApi {
     this.extracted = 6;
     this.bytes = 2.6 * 2 ** 30;
     this.log = [
-      ["▶  85 links  ·  16 extractors  ·  8 streams  ·  3 retries  ·  v3.0", "info"],
+      ["▶  85 links  ·  16 extractors  ·  8 streams  ·  3 retries  ·  v4.0", "info"],
       ["   fuckingfast: direct HTTP   ·   datanodes: 8 pages, captcha 30s", "dim"],
       ["   chrome: C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe", "dim"],
       ["   proxies: 12 loaded — rotating per download", "info"],
@@ -1210,7 +1210,7 @@ class MockApi {
   }
 
   async hello() {
-    return { version: "v3.0 · preview", have_curl: true, settings: {
+    return { version: "v4.0 · preview", have_curl: true, settings: {
       out_folder: "D:\\downloads", mode: "download", workers: 16, dl_streams: 8, retries: 3,
       dn_pages: 8, dn_captcha: 30,
       dn_chrome: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",

--- a/web/index.html
+++ b/web/index.html
@@ -71,7 +71,7 @@
       <div class="pill" id="statePill" data-state="idle">
         <span class="dot"></span><span class="pill-label" id="stateLabel">IDLE</span>
       </div>
-      <span class="version" id="version">v3.0</span>
+      <span class="version" id="version">v4.0</span>
     </div>
     <div class="topbar-progress"><i id="globalBar"></i></div>
   </header>


### PR DESCRIPTION
Both providers changed how they hand out links and every download stopped. This
is the repair. The GUI is unchanged since 3.0.

## datanodes.to removed step 1

The share URL used to return a form whose submit carried
`name="method_free" value="Free Download >>"`. It now answers with step 2
directly — tokens already minted, and the page says "STEP 2 OF 2" on screen.

The extractor waited 22s for `#downloadReveal` and `#method_free`, timed out and
gave up **before ever reaching the trigger chain that was already working**. The
signature is unmistakable: 22.5s per link against a 22.0s budget.

It now waits for whichever shape the server sends and branches on the page
rather than on an assumption; the old two-step path still runs when the old
markup arrives. Skipping the obsolete POST matters on its own — a second
`POST /download` re-runs SecSave and invalidates the token step 2 is holding, so
the run was destroying its own session.

The wait is now `max(step-1 budget, manual captcha budget)`: on the new shape
the controls only appear once Cloudflare has been answered, and 22s is not a
human budget.

## fuckingfast.co put Turnstile in front of `POST /f/<id>/go`

403 `captcha verification failed` without a `cf-turnstile-response` token, which
no TLS fingerprint can mint. Ruled out first: **not** the impersonation (the page
returns 200) and **not** a missing session (same cookies, and an empty token
field, both still 403). No official alternative exists — no API, no docs, no
premium tier, no registration; the bundle exposes only upload endpoints.

Refused links now go through the browser the app already opens for datanodes.
**A batch fuckingfast still serves over plain HTTPS opens no window**, so the
guarantee `tests/test_no_chrome.py` exists to protect still holds.

Three defects found while building that path, all introduced by me and caught by
the maintainer testing it:

- the widget locator matched `.cf-turnstile` as a **class** and an iframe whose
  `src` contains `challenges.cloudflare`. fuckingfast uses it as an **id** and
  its challenge iframe has no `src` at all, so the auto-click had no target —
  the box sat on screen, never clicked
- the trigger is `click[!!window.turnstileToken || !!window.dlCleared]`. The OR
  matters: the flag never arms and the click submits anyway, so waiting for a
  token waited for something that never comes. It now clicks, closes the ad tab
  the first click opens, and clicks again — what a person does
- per-link `browser.new_context()` is the **v14.6 mistake already recorded above
  `acquire_lane`**; and popup/route handlers registered on the shared context
  piled up one per link, stalling everything after the first. Page-scoped now,
  which took the sequence from 1/3 to 3/3

## Verified

| | result |
|:--|:--|
| datanodes, CLI end to end | 5/5 |
| datanodes, extraction | 2/2 |
| fuckingfast, consecutive | 3/3 at 6.8–9.7s |
| both providers together | 4/4 |
| `pytest tests/ -q` | 24 passed |

fuckingfast was measured with `MOON_DN_CAPTCHA_WAIT=0` — auto-solve only, no
manual tick possible.

The GUI no longer claims fuckingfast "has no captcha".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
