### PR TITLE
fix: use Proxy-Authorization header for proxy auth

### DIFF
--- a/moon_download.py
+++ b/moon_download.py
@@ -111,7 +111,7 @@ def parse_proxy_line(line: str) -> dict | None:
                 user, passwd, ip, port = parts
             return {
                 "url": f"http://{ip}:{port}",
-                "auth": aiohttp.BasicAuth(user, passwd),
+                "auth": _proxy_auth_header(user, passwd),
             }
         elif len(parts) == 2:
             ip, port = parts
@@ -119,6 +119,13 @@ def parse_proxy_line(line: str) -> dict | None:
     except Exception:
         pass
     return None
+
+
+def _proxy_auth_header(user: str, passwd: str) -> str:
+    """Build a Proxy-Authorization header value without deprecated BasicAuth."""
+    if hasattr(aiohttp, "encode_basic_auth"):
+        return aiohttp.encode_basic_auth(user, passwd)
+    return aiohttp.BasicAuth(user, passwd).encode()
 
 def count_usable_proxies(path: str) -> tuple[int, int]:
     if not os.path.exists(path):
@@ -495,7 +502,8 @@ async def download_file(
             req_kwargs = dict(headers=hdrs)
             if dl_proxy:
                 req_kwargs["proxy"] = dl_proxy
-                req_kwargs["proxy_auth"] = dl_proxy_auth
+                if dl_proxy_auth:
+                    hdrs["Proxy-Authorization"] = dl_proxy_auth
 
             async with dl_session.get(proxy_url, **req_kwargs) as r:
                 if r.status == 416:

--- a/tests/test_proxy_pool.py
+++ b/tests/test_proxy_pool.py
@@ -1,5 +1,26 @@
 import pytest
-from moon_download import ProxyPool
+from moon_download import ProxyPool, parse_proxy_line
+
+
+def test_parse_proxy_line_builds_proxy_auth_header():
+    cfg = parse_proxy_line("1.2.3.4:8080:user:pass")
+    assert cfg is not None
+    assert cfg["url"] == "http://1.2.3.4:8080"
+    assert cfg["auth"] == "Basic dXNlcjpwYXNz"
+
+
+def test_parse_proxy_line_builds_auth_header_for_credentials_first():
+    cfg = parse_proxy_line("user:pass:5.6.7.8:9090")
+    assert cfg is not None
+    assert cfg["url"] == "http://5.6.7.8:9090"
+    assert cfg["auth"] == "Basic dXNlcjpwYXNz"
+
+
+def test_parse_proxy_line_no_auth_for_two_part_line():
+    cfg = parse_proxy_line("5.6.7.8:9090")
+    assert cfg is not None
+    assert cfg["url"] == "http://5.6.7.8:9090"
+    assert cfg["auth"] is None
 
 
 def test_proxy_pool_load_valid(tmp_path):


### PR DESCRIPTION
Closes #151.

Builds proxy credentials as a `Proxy-Authorization` header value instead of `aiohttp.BasicAuth`. Uses `aiohttp.encode_basic_auth` when available and falls back to `BasicAuth(...).encode()` otherwise, so the `aiohttp>=3.9` floor does not change.

Verified:
- `pytest tests/ -q` -> 32 passed
- `python -W error::DeprecationWarning -m pytest tests/test_proxy_pool.py -q` -> 8 passed