### PR TITLE
fix: remove the never-failing ok assertion in test_no_chrome.py (#155)

### DIFF
--- a/tests/test_no_chrome.py
+++ b/tests/test_no_chrome.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import os
 import pathlib
 import re
 import tempfile
@@ -49,18 +48,15 @@ def run_engine(engine, urls, retries=1) -> dict:
     return {"ok": metrics["ok"], "fail": metrics["fail"]}
 
 
-def run_cli(urls, retries=1) -> dict:
+def run_cli(urls, retries=1) -> None:
     with tempfile.TemporaryDirectory() as out:
         asyncio.run(moon_cli.run(urls, out, 4, 4, retries, "proxies.txt"))
-        done = len(os.listdir(out))
-    return {"ok": len(urls) if done == 0 else done, "fail": 0}
 
 
-def assert_browser_counts(result, calls, urls, want_browsers: int) -> None:
+def assert_browser_counts(calls, want_browsers: int) -> None:
     assert calls["open_browser"] == want_browsers
     assert calls["playwright"] == want_browsers
     assert calls["close_browser"] + calls["shutdown_chrome"] == want_browsers
-    assert result["ok"] == len(urls)
 
 
 def cleanup() -> None:
@@ -81,20 +77,20 @@ def cleanup() -> None:
 
 def test_engine_fuckingfast_only_launches_no_browser(browser_calls):
     engine = moon_engine.Engine()
-
     try:
         result = run_engine(engine, FF)
-        assert_browser_counts(result, browser_calls, FF, want_browsers=0)
+        assert result["ok"] == len(FF)
+        assert_browser_counts(browser_calls, want_browsers=0)
     finally:
         cleanup()
 
 
 def test_engine_mixed_batch_launches_one_shared_browser(browser_calls):
     engine = moon_engine.Engine()
-
     try:
         result = run_engine(engine, FF + DN)
-        assert_browser_counts(result, browser_calls, FF + DN, want_browsers=1)
+        assert result["ok"] == len(FF + DN)
+        assert_browser_counts(browser_calls, want_browsers=1)
     finally:
         cleanup()
 
@@ -124,16 +120,16 @@ def test_engine_unsupported_host_fails_once_without_browser(browser_calls):
 
 def test_cli_fuckingfast_only_launches_no_browser(browser_calls):
     try:
-        result = run_cli(FF)
-        assert_browser_counts(result, browser_calls, FF, want_browsers=0)
+        run_cli(FF)
+        assert_browser_counts(browser_calls, want_browsers=0)
     finally:
         cleanup()
 
 
 def test_cli_mixed_batch_launches_one_shared_browser(browser_calls):
     try:
-        result = run_cli(FF + DN)
-        assert_browser_counts(result, browser_calls, FF + DN, want_browsers=1)
+        run_cli(FF + DN)
+        assert_browser_counts(browser_calls, want_browsers=1)
     finally:
         cleanup()
 


### PR DESCRIPTION
Fixes #155

## Description

`run_cli` in `tests/test_no_chrome.py` reported success when a run wrote no
files: with `done == 0` it set `ok` to `len(urls)`, so the `ok` assertion in
`assert_browser_counts` could never fail on the CLI path.

Removed:
- the vacuous `assert result["ok"] == len(urls)` from the shared helper
- the now-dead `result` / `urls` parameters from `assert_browser_counts`
- the fake `ok` / `fail` accounting in `run_cli` (its return value had no consumers)
- the now-unused `import os`

The `ok` check is genuine on the engine path — `run_engine` returns the engine's
real counters — so it was restored in `test_engine_fuckingfast_only_launches_no_browser`
and `test_engine_mixed_batch_launches_one_shared_browser`, where it still fails
if the engine drops a URL. The CLI tests no longer assert against a fabricated `ok`.

`assert_browser_counts` now only checks the browser counts, which the stubs
actually exercise.

**Why this option:** dropped the fabricated `ok` assertion rather than making
the stubs write files. The browser counts already carry the intent of these
tests, and an assertion that passes by construction means nothing. The genuine
engine-path check is kept because it is doing real work.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [ ] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py`
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR
      description

## Screenshots / logs (if applicable)

<img width="678" height="205" alt="图片" src="https://github.com/user-attachments/assets/f3a12a15-9c93-48ce-a713-e7e04b8349c6" />
