### PR TITLE
ci: run ruff once outside syntax matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,17 @@ jobs:
       - name: Byte-compile every module
         run: git ls-files '*.py' | xargs python -m compileall -q
 
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+
       - name: Install ruff
         run: pip install "ruff==0.16.1"
 


### PR DESCRIPTION
## Description

Fixes #81

Move the pinned Ruff install and lint steps into a standalone Python 3.10 job. Ruff now runs once per workflow while `syntax-check` continues to byte-compile every tracked Python module on Python 3.10 through 3.14.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [x] Other: CI workflow maintenance

## Checklist

- [x] I have tested my changes locally
- [x] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py`
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR
      description

Shared extraction and download logic is unaffected; this change only adjusts the lint workflow.

## Testing

- `.venv/bin/ruff check .`
- `python3.10 -m compileall -q`, through `python3.14 -m compileall -q`, on every tracked Python file
- `actionlint .github/workflows/lint.yml`

## Screenshots / logs (if applicable)

N/A — CI-only change.
