### PR TITLE
removed the dead theme block in moon_engine.py

### DIFF
--- a/moon_engine.py
+++ b/moon_engine.py
@@ -44,22 +44,7 @@ from moon_download import (
     RunFatalControl,
 )
 
-# ── THEME ──────────────────────────────────────────────────────────────────────
-BG      = "#080b12"
-BG2     = "#0c1018"
-BG3     = "#111520"
-SURFACE = "#161c2a"
-BORDER  = "#1e2840"
-ACC     = "#00d4ff"
-ACC2    = "#0099cc"
-ACC3    = "#00ffb3"
-GOLD    = "#f5a623"
-TEXT    = "#e8f0ff"
-TEXT2   = "#8899bb"
-TEXT3   = "#3d506e"
-OK      = "#00e676"
-ERR     = "#ff4d6d"
-WARN    = "#ffb547"
+
 # ── EXTRACTION ────────────────────────────────────────────────────────────────
 # Both host front-ends changed in 2026; the extraction layer now lives in
 # moon_extract.py so the engine and the CLI share one implementation.


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR changes and why. --> I have removed the dead theme block at the top of moon_engine.py as it had no use in the code due to the introduction of web/styles.css, which has its own palette in CSS custom properties and shares not one hex value with this block.

Addresses #145

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [x] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [ ] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py`
      — not applicable: this removes an unused constant block with zero
      references, no shared logic touched.
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR
      description

## Screenshots / logs (if applicable)

<img width="569" height="173" alt="Screenshot 2026-08-08 at 1 49 13 PM" src="https://github.com/user-attachments/assets/2977252e-6a78-4f14-8efc-d388531b232c" />

<!-- Attach screenshots or `moontech_*.log` snippets if this is a UI or
     download-engine change. -->
