### PR TITLE
test: suppress aiohttp BasicAuth deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+filterwarnings =
+    # aiohttp.BasicAuth is deprecated, but proxy_auth still requires it.
+    # Keep BasicAuth because header-based proxy auth fails for HTTPS connections.
+    # See issue #151.
+    ignore:BasicAuth is deprecated and will be removed in aiohttp 4\.0:DeprecationWarning


### PR DESCRIPTION
## Description

Adds a targeted pytest warning filter for the `aiohttp.BasicAuth` deprecation warning in `pytest.ini`.

`aiohttp.BasicAuth` is intentionally kept because it is still required for proxy authentication, including HTTPS proxy connections. The warning is suppressed only during pytest runs rather than changing the application code.

## Type of change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would change existing behavior)
* [ ] Documentation update
* [ ] Refactor / code cleanup
* [ ] Other:

## Checklist

* [x] I have tested my changes locally
* [ ] If this affects shared logic (extraction, download engine), I also
  applied the equivalent change to `moon_cli.py`
* [x] I have kept the single-file architecture (no package split)
* [x] I have not added new dependencies without justification in the PR
  description

## Screenshots / logs (if applicable)

Tests:

* `uv run pytest tests/` — 50 passed
* `act -j no-chrome` — passed
* `act -j ruff` — passed

Closes #151
