### PR TITLE
fix: apply the download_file stub to moon_engine too (#160)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,9 +59,10 @@ def browser_calls(monkeypatch):
     monkeypatch.setattr(moon_extract, "shutdown_chrome", fake_shutdown_chrome)
 
     for host in (moon_engine, moon_cli):
+        # Every stub in this loop must cover both moon_engine and moon_cli. Break that and the engine keeps the real function — it will actually try to make network requests, because monkeypatch never replaced its download_file.
         monkeypatch.setattr(host, "extract_fuckingfast", fake_ff)
         monkeypatch.setattr(host, "extract_datanodes", fake_dn)
         monkeypatch.setattr(host, "close_ff_session", lambda: asyncio.sleep(0))
-    monkeypatch.setattr(moon_cli, "download_file", fake_download)
+        monkeypatch.setattr(host, "download_file", fake_download)
 
     return calls


### PR DESCRIPTION
## Description
Close #160
Resolved the issue in #160 by modifying the erroneous line 66 in conftest.py (monkeypatch.setattr(moon_cli, "download_file", fake_download))) (which could potentially cause the engine to attempt a real download) to monkeypatch.setattr(host, "download_file", fake_download)
<img width="1024" height="313" alt="图片" src="https://github.com/user-attachments/assets/3d3b5245-a837-44af-9146-1387b12dadaa" /> and moved it into the for host in (moon_engine, moon_cli): loop, while adding a comment stating that this monkeypatch statement should not be moved.
This modification only involves conftest.py and does not involve any other changes.
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [ ] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py`
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR
      description

## Screenshots / logs (if applicable)
<img width="1920" height="1020" alt="图片" src="https://github.com/user-attachments/assets/53ed0d98-24d8-4307-b055-4651a79e7c1d" />
↑Normal state
<img width="1920" height="1020" alt="图片" src="https://github.com/user-attachments/assets/b763e8e2-e5a7-4260-8b81-fa7a174c4ec1" />
↑The state after commenting out lines 181 and 255