### PR TITLE
conftest stubs download_file on moon_cli only — the engine keeps...

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,10 +58,13 @@ def browser_calls(monkeypatch):
     monkeypatch.setattr(moon_extract, "close_browser", fake_close_browser)
     monkeypatch.setattr(moon_extract, "shutdown_chrome", fake_shutdown_chrome)
 
+    # Both front-ends import their own copy of each of these names, so both
+    # must be patched here -- patching only one leaves the other holding the
+    # real implementation, invisibly, until something exercises it.
     for host in (moon_engine, moon_cli):
         monkeypatch.setattr(host, "extract_fuckingfast", fake_ff)
         monkeypatch.setattr(host, "extract_datanodes", fake_dn)
         monkeypatch.setattr(host, "close_ff_session", lambda: asyncio.sleep(0))
-    monkeypatch.setattr(moon_cli, "download_file", fake_download)
+        monkeypatch.setattr(host, "download_file", fake_download)
 
     return calls

--- a/tests/test_no_chrome.py
+++ b/tests/test_no_chrome.py
@@ -27,11 +27,11 @@ DOWNLOAD_DEFS = (
 )
 
 
-def run_engine(engine, urls, retries=1) -> dict:
+def run_engine(engine, urls, retries=1, mode="links") -> dict:
     res = engine.start(
         {
             "links": urls,
-            "mode": "links",
+            "mode": mode,
             "out_folder": str(ROOT / "_tmp_out"),
             "workers": 4,
             "dl_streams": 4,
@@ -45,7 +45,7 @@ def run_engine(engine, urls, retries=1) -> dict:
         time.sleep(0.15)
 
     metrics = engine.snapshot(0)["metrics"]
-    return {"ok": metrics["ok"], "fail": metrics["fail"]}
+    return {"ok": metrics["ok"], "fail": metrics["fail"], "dl_done": metrics["dl_done"]}
 
 
 def run_cli(urls, retries=1) -> None:
@@ -95,6 +95,20 @@ def test_engine_mixed_batch_launches_one_shared_browser(browser_calls):
         cleanup()
 
 
+def test_engine_download_mode_uses_stubbed_download_file(browser_calls):
+    # moon_engine imports download_file straight from moon_download, a
+    # separate name from moon_cli's. If the fixture only patches moon_cli's
+    # copy, this hits the real downloader against a fake URL instead of the
+    # stub -- see #160.
+    engine = moon_engine.Engine()
+    try:
+        result = run_engine(engine, FF, mode="download")
+        assert result == {"ok": len(FF), "fail": 0, "dl_done": len(FF)}
+        assert_browser_counts(browser_calls, want_browsers=0)
+    finally:
+        cleanup()
+
+
 def test_engine_unsupported_host_fails_once_without_browser(browser_calls):
     engine = moon_engine.Engine()
 
@@ -104,7 +118,7 @@ def test_engine_unsupported_host_fails_once_without_browser(browser_calls):
         messages = [message for message, _tag in snapshot["log"]]
         record = engine._tracked[UNSUPPORTED[0]]
 
-        assert result == {"ok": 0, "fail": 1}
+        assert result == {"ok": 0, "fail": 1, "dl_done": 0}
         assert browser_calls["open_browser"] == 0
         assert browser_calls["playwright"] == 0
         assert record.status == "fail"


### PR DESCRIPTION
Fixes #160

conftest stubbed download_file on moon_cli only, leaving moon_engine holding the real function; moved the patch inside the shared host loop so both front-ends get it, with a comment explaining why.

**Testing:** Added test_engine_download_mode_uses_stubbed_download_file, which fails without the fix and passes with it; also confirmed it turns red when the engine drops a success increment, per the issue's verification recipe. Ran the full suite (pytest tests/ -q): 51 passed.

---

## Description

<!-- Briefly describe what this PR changes and why. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [ ] I have tested my changes locally
- [ ] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py`
- [ ] I have kept the single-file architecture (no package split)
- [ ] I have not added new dependencies without justification in the PR
      description

## Screenshots / logs (if applicable)

<!-- Attach screenshots or `moontech_*.log` snippets if this is a UI or
     download-engine change. -->