### PR TITLE
ci: watch lint and test configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
       - "**.py"
       - "requirements.txt"
       - "constraints.txt"
+      - "ruff.toml"
+      - "pytest.ini"
       - ".github/dependabot.yml"
       - ".github/workflows/lint.yml"
   pull_request:
@@ -14,6 +16,8 @@ on:
       - "**.py"
       - "requirements.txt"
       - "constraints.txt"
+      - "ruff.toml"
+      - "pytest.ini"
       - ".github/dependabot.yml"
       - ".github/workflows/lint.yml"
 


### PR DESCRIPTION
## Description

Closes #164.

Adds `ruff.toml` and `pytest.ini` to both the push and pull-request path filters for the lint workflow. This ensures configuration-only changes run the checks they control. `docs-cli-check.yml` is intentionally unchanged because neither file configures documentation checks.

Verification:

- `pytest tests/ -q` — 50 passed
- `uvx ruff==0.16.1 check .` — passed
- Parsed `.github/workflows/lint.yml` with PyYAML — valid
- CI trigger proof: [run 31559809262](https://github.com/LeyckerS/moondownloader/actions/runs/31559809262), fired for the initial commit's temporary comment-only `ruff.toml` change

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [x] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py` (N/A; CI-only change)
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR
      description

## Screenshots / logs (if applicable)

N/A — CI-only change.
