### PR TITLE
cleanup: drop the unused _LOG_MAX_LINES constant

### DIFF
--- a/moon_engine.py
+++ b/moon_engine.py
@@ -137,8 +137,6 @@ class Engine:
     def _get(self, attr):
         with self._lock: return getattr(self, attr)
 
-    _LOG_MAX_LINES = 2000
-
     def log(self, msg, tag=""):
         """Thread-safe: called from the asyncio worker, drained by snapshot()."""
         with self._log_lock:


### PR DESCRIPTION
Removed the unused _LOG_MAX_LINES constant and the blank line after it, per the issue.

Ran `grep -rn "_LOG_MAX_LINES" .` after the change — zero matches,
confirming nothing else in the codebase referenced it