### PR TITLE
fix(gui): expose the datanodes extractor limit

### DIFF
--- a/tests/test_gui_extractor_scope.py
+++ b/tests/test_gui_extractor_scope.py
@@ -1,0 +1,26 @@
+"""Regression coverage for the provider-specific extractor ceiling in the GUI."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = (ROOT / "web" / "index.html").read_text(encoding="utf-8")
+APP = (ROOT / "web" / "app.js").read_text(encoding="utf-8")
+
+
+def test_extractor_hint_has_a_dedicated_live_target():
+    assert 'id="extractorScope"' in INDEX
+    assert 'id="workers"' in INDEX
+    assert 'id="pages"' in INDEX
+
+
+def test_extractor_hint_reports_the_effective_datanodes_limit():
+    assert "Math.min(workerCount, pageCount)" in APP
+    assert 'T("extractors_hint", Math.min(workerCount, pageCount), pageCount)' in APP
+
+
+def test_extractor_hint_tracks_both_controls_and_language_changes():
+    assert '$("#workers").addEventListener("input", syncExtractorScope)' in APP
+    assert '$("#pages").addEventListener("input", syncExtractorScope)' in APP
+    assert APP.count("syncExtractorScope();") >= 2
+    assert APP.count("extractors_hint:") == 2

--- a/web/app.js
+++ b/web/app.js
@@ -34,6 +34,7 @@ const I18N = {
     mode_download: "Download", mode_links: "Links only",
     common: "Common", common_sub: "· both methods",
     extractors: "Extractors", dl_streams: "DL streams", retries: "Retries",
+    extractors_hint: (n, pages) => `datanodes uses up to ${n} extractors (Pages ${pages})`,
     rec16: "rec. 16", rec8: "rec. 8", rec8p: "rec. 8",
     note_streams: "fewer streams = more bandwidth per file; the pipe is still the ceiling",
     dn_note: "Real Chrome + Turnstile: it opens pages, not windows",
@@ -87,6 +88,7 @@ const I18N = {
     mode_download: "Download", mode_links: "Solo link",
     common: "Comuni", common_sub: "· entrambi i metodi",
     extractors: "Extractors", dl_streams: "DL streams", retries: "Retries",
+    extractors_hint: (n, pages) => `datanodes usa fino a ${n} estrattori (Pages ${pages})`,
     rec16: "cons. 16", rec8: "cons. 8", rec8p: "cons. 8",
     note_streams: "pochi stream = piu banda per file; la pipe resta il tetto",
     dn_note: "Chrome reale + Turnstile: apre pagine, non finestre",
@@ -153,6 +155,7 @@ function applyLang(lang) {
   setRunState(ui.runState);
   editor.counts();
   syncDnChip();
+  syncExtractorScope();
   if (ui.lastMetrics) renderMetrics(ui.lastMetrics, true);
   if (ui.lastFiles) {
     // Row labels are only written when the state CHANGES, so a language switch
@@ -386,6 +389,16 @@ function initSlider(id, outId, suffix = "") {
   input.addEventListener("input", () => { paint(); scheduleSettingsSave(); });
   paint();
   return input;
+}
+
+function syncExtractorScope() {
+  const hint = $("#extractorScope");
+  const workers = $("#workers");
+  const pages = $("#pages");
+  if (!hint || !workers || !pages) return;
+  const workerCount = Number(workers.value);
+  const pageCount = Number(pages.value);
+  hint.textContent = T("extractors_hint", Math.min(workerCount, pageCount), pageCount);
 }
 
 /* ── run state ────────────────────────────────────────────────────────── */
@@ -1044,6 +1057,9 @@ async function boot() {
   initSlider("retries", "outRetries");
   initSlider("pages", "outPages");
   initSlider("captcha", "outCaptcha", "s");
+  $("#workers").addEventListener("input", syncExtractorScope);
+  $("#pages").addEventListener("input", syncExtractorScope);
+  syncExtractorScope();
   initTabs();
   initSpotlight();
   initDropzone();

--- a/web/index.html
+++ b/web/index.html
@@ -146,6 +146,7 @@
             <span class="s-hint" data-i18n="rec16">rec. 16</span>
             <output id="outWorkers">16</output>
             <input type="range" id="workers" min="2" max="32" step="1" value="16" data-rec="16">
+            <span class="scope-note" id="extractorScope">datanodes uses up to 8 extractors (Pages 8)</span>
           </label>
 
           <label class="slider" data-accent="violet">

--- a/web/styles.css
+++ b/web/styles.css
@@ -430,6 +430,13 @@ svg { fill: none; stroke: currentColor; stroke-width: 1.35; stroke-linecap: roun
 
 .s-label { font-family: var(--mono); font-size: 0.68rem; color: var(--txt2); }
 .s-hint  { font-family: var(--mono); font-size: 0.58rem; color: var(--txt3); }
+.scope-note {
+  grid-column: 1 / -1;
+  margin-top: -0.15rem;
+  font-family: var(--mono);
+  font-size: 0.56rem;
+  color: var(--txt3);
+}
 .slider output {
   font-family: var(--mono); font-size: 0.8rem; font-weight: 700;
   color: var(--accent); min-width: 2.6em; text-align: right;


### PR DESCRIPTION
Closes #83

## Description

The shared `Extractors` slider now states the effective datanodes concurrency limit instead of implying that every selected worker can open a datanodes page.

The note is derived from `min(Extractors, Pages)`, updates immediately when either slider moves, and is relabelled when the UI switches between English and Italian. I chose the issue's option 1 because the eight-page ceiling protects the shared Chrome context; explaining the effective limit fixes the misleading control without weakening that guardrail.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [x] If this affects shared logic (extraction, download engine), I also applied the equivalent change to `moon_cli.py` (not applicable: presentation-only GUI change)
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR description

## Verification

- Regression test against the unmodified tree: `3 failed`
- `python -m pytest tests/ -q`: `53 passed`
- `ruff check .`: passed
- `node --check web/app.js`: passed
- Headless Chromium runtime checks: effective limit changed `8 -> 6 -> 4`, EN/IT relabelling passed, no page errors
- `python render_gui.py <out> 1440 900`: no JS errors, overflow, or horizontal scroll

The extraction and download paths are unchanged; both provider configurations continue to flow through the same existing engine settings.