### PR TITLE
docs(ruff): correct the E501 comment

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -7,7 +7,7 @@ target-version = "py310"
 [lint]
 select = ["E", "F", "W", "I"]
 ignore = [
-    "E501",  # line length - handled above via line-length instead
+    "E501",  # line length is not enforced: ruff format is not run in CI
     # Everything below fires on the codebase as it stands today. Per the issue that
     # introduced this file: the goal is a green baseline that catches regressions, not
     # a reformat, so these are parked here rather than fixed inline. Each is a real,


### PR DESCRIPTION
docs(ruff): correct the E501 comment

## Description

This is a documentation change, replaces the incorrect documentation of E501 (line 10) on ruff.toml for a correct one

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] Other:

## Checklist

- [x] I have tested my changes locally
- [x] If this affects shared logic (extraction, download engine), I also
      applied the equivalent change to `moon_cli.py`
- [x] I have kept the single-file architecture (no package split)
- [x] I have not added new dependencies without justification in the PR
      description

## Screenshots / logs (if applicable)

<!-- Attach screenshots or `moontech_*.log` snippets if this is a UI or
     download-engine change. -->
