### PR TITLE
ci: add syntax check for web/ changes (fixes #174)

### DIFF
--- a/.github/workflows/web-syntax.yml
+++ b/.github/workflows/web-syntax.yml
@@ -1,0 +1,27 @@
+name: Web Syntax Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/web-syntax.yml"
+  pull_request:
+    paths:
+      - "web/**"
+      - ".github/workflows/web-syntax.yml"
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Syntax check web/app.js
+        run: node --check web/app.js


### PR DESCRIPTION
## Problem
PRs that touch only `web/**` run no CI at all — not even a syntax check (issue #174).

## Solution
Added a GitHub Actions workflow that runs `node --check web/app.js` on every push/PR affecting files under `web/**`.

## Testing
- Validated locally: `node --check web/app.js` passes
- Workflow triggers on `web/**` paths only (minimal scope)
- Uses Node.js 22 (current LTS) via `actions/setup-node@v4`

## Changes
- New file: `.github/workflows/web-syntax.yml`
