### PR TITLE
Fix stall re-extraction failure accounting

### DIFF
--- a/moon_cli.py
+++ b/moon_cli.py
@@ -270,7 +270,7 @@ async def run(urls: list[str], output_dir: str, n_workers: int,
                 await q.put((url, attempt+1, rec))
                 q.task_done(); continue
 
-            if not success and not is_re and not fatal_control.is_set():
+            if not success and not fatal_control.is_set():
                 with lock: fail_count += 1
                 failed_urls.append(url)
                 rec.status = "fail"; mark_done()

--- a/moon_engine.py
+++ b/moon_engine.py
@@ -326,7 +326,7 @@ class Engine:
                     await q.put((url, attempt+1, rec))
                     q.task_done(); continue
 
-                if not success and not is_re and not fatal_control.is_set():
+                if not success and not fatal_control.is_set():
                     self._inc("_fail"); failed_urls.append(url)
                     rec.status="fail"; mark_done_fn()
 

--- a/tests/test_stall_reextraction.py
+++ b/tests/test_stall_reextraction.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+
+import moon_cli
+import moon_engine
+
+
+def test_engine_stall_reextract_failure_completes(monkeypatch, tmp_path):
+    url = "https://fuckingfast.co/example/file.zip"
+    extract_calls = []
+    download_calls = []
+
+    async def fake_extract(_url, _get_browser):
+        extract_calls.append(_url)
+
+        if len(extract_calls) == 1:
+            return "https://dl.fuckingfast.co/fake.zip?fake"
+
+        return None
+
+    async def fake_download(
+        _proxy_url,
+        _cookies,
+        _dest,
+        _rec,
+        _bytes_acc,
+        _kill_evt,
+        _kills_so_far,
+        telem=None,
+        on_event=None,
+        fatal_control=None,
+    ):
+        download_calls.append(_rec.url)
+        return False, "stall_killed", 4096
+
+    monkeypatch.setattr(moon_engine, "extract_fuckingfast", fake_extract)
+    monkeypatch.setattr(moon_engine, "download_file", fake_download)
+
+    engine = moon_engine.Engine()
+
+    result = engine.start(
+        {
+            "links": [url],
+            "mode": "download",
+            "out_folder": str(tmp_path),
+            "workers": 1,
+            "dl_streams": 1,
+            "retries": 0,
+        }
+    )
+
+    thread = engine._thread
+    assert thread is not None
+
+    try:
+        assert result["ok"] is True
+
+        # Wait for the Engine thread to finish.
+        # This directly verifies that the failed re-extraction
+        # does not leave the queue waiting forever.
+        thread.join(timeout=2.0)
+
+        assert not thread.is_alive()
+
+        assert extract_calls == [url, url]
+        assert download_calls == [url]
+
+        snapshot = engine.snapshot(0)
+
+        assert not engine._get("_running")
+        assert snapshot["state"] == "done"
+        assert snapshot["metrics"]["fail"] == 1
+        assert snapshot["metrics"]["dl_done"] == 0
+        assert engine._tracked[url].status == "fail"
+
+    finally:
+        engine.stop()
+
+        if engine._thread is not None:
+            engine._thread.join(timeout=2)
+
+
+def test_cli_stall_reextract_failure_completes(monkeypatch, tmp_path):
+    url = "https://fuckingfast.co/example/file.zip"
+    extract_calls = []
+    download_calls = []
+
+    async def fake_extract(_url, _get_browser):
+        extract_calls.append(_url)
+
+        if len(extract_calls) == 1:
+            return "https://dl.fuckingfast.co/fake.zip?fake"
+
+        return None
+
+    async def fake_download(
+        _proxy_url,
+        _cookies,
+        _dest,
+        _rec,
+        _bytes_acc,
+        _kill_evt,
+        _kills_so_far,
+        telem=None,
+        on_event=None,
+        fatal_control=None,
+    ):
+        download_calls.append(_rec.url)
+
+        # Prevent the CLI's elapsed-time calculation from seeing
+        # a zero-second run on a very fast fake download.
+        await asyncio.sleep(0.01)
+
+        return False, "stall_killed", 4096
+
+    monkeypatch.setattr(moon_cli, "extract_fuckingfast", fake_extract)
+    monkeypatch.setattr(moon_cli, "download_file", fake_download)
+
+    result = asyncio.run(
+        moon_cli.run(
+            [url],
+            str(tmp_path / "downloads"),
+            1,
+            1,
+            0,
+            "proxies.txt",
+        )
+    )
+
+    assert extract_calls == [url, url]
+    assert download_calls == [url]
+    assert result == (0, 1, False)


### PR DESCRIPTION
## Summary

Fixes #178.

When a download is killed because of a stall, the URL is re-extracted. If that re-extraction fails, the URL was not counted as a terminal failure, leaving queue accounting incomplete and causing the frontends to wait indefinitely.

This change treats a failed stall re-extraction as a terminal failure in both frontends.

## Changes

- Count failed stall re-extraction as one failed URL in `moon_engine.py`.
- Apply the same accounting fix in `moon_cli.py`.
- Keep the existing `not is_re` retry guard unchanged.
- Add regression tests covering both the Engine and CLI paths.

### Verification

- Regression tests: 2 passed
- CLI progress + regression tests: 6 passed
- Full test suite: 70 passed
- Repeated Engine regression test: 5/5 passed
- `git diff --cached --check`: clean
- GitHub CI: 9/9 checks passed